### PR TITLE
fix typo in __logo.tpl

### DIFF
--- a/templates/__logo.tpl
+++ b/templates/__logo.tpl
@@ -1,1 +1,1 @@
-{if $__cms->isActiveApplication()}{{if !$__wcf->getStyleHandler()->getStyle()->getPageLogo()}<img src="{@$__wcf->getPath('cms')}images/fireball.png" alt="" />{/if}{/if}
+{if $__cms->isActiveApplication() && !$__wcf->getStyleHandler()->getStyle()->getPageLogo()}<img src="{@$__wcf->getPath('cms')}images/fireball.png" alt="" />{/if}


### PR DESCRIPTION
There was a `{` too much in the `__logo.tpl`. Have also merged both conditions to one, it's cleaner ;)
