### PR TITLE
ensure files folder is within version control

### DIFF
--- a/files/files/.gitignore
+++ b/files/files/.gitignore
@@ -1,0 +1,3 @@
+# This file ensures this directory is within version control since git does
+# only track files. This directory is meant to be empty
+*


### PR DESCRIPTION
The change with this pull request ensures that the `files` folder is within version control. Otherwise there might be permission issues writing in that folder when creating new folders or files via the acp.
