### PR TITLE
page add form reordering & language improvements

### DIFF
--- a/acptemplates/fileAdd.tpl
+++ b/acptemplates/fileAdd.tpl
@@ -187,7 +187,7 @@
         </table>
     </div>
 {else}
-<p class="info">{lang}cms.acp.files.noItems{/lang}</p>
+	<p class="info">{lang}wcf.global.noItems{/lang}</p>
 {/if}
 
 {include file='footer'}

--- a/acptemplates/pageAdd.tpl
+++ b/acptemplates/pageAdd.tpl
@@ -45,7 +45,7 @@
 </nav>
 
 <header class="boxHeadline">
-    <h1>{lang}cms.acp.page.{@$action}{/lang}{if $action != 'add'}{if $page->isHome} <span class="icon icon16 icon-home jsTooltip" title="{lang}cms.acp.page.homePage{/lang}"></span>{/if}{/if}</h1>
+	<h1>{lang}cms.acp.page.{@$action}{/lang}{if $action != 'add'}{if $page->isHome} <span class="icon icon16 icon-home jsTooltip" title="{lang}cms.acp.page.homePage{/lang}"></span>{/if}{/if}</h1>
 </header>
 
 {include file='formError'}
@@ -86,22 +86,8 @@
 			<fieldset>
 				<legend>{lang}wcf.global.form.data{/lang}</legend>
 
-				{if $pageList != null}
-					<dl{if $errorField == 'parentID'} class="formError"{/if}>
-						<dt><label for="parentID">{lang}cms.acp.page.general.parentID{/lang}</label></dt>
-						<dd>
-							<select id="parentID" name="parentID">
-								<option value="0" {if parentID == 0} selected="selected"{/if} data-alias="">{lang}wcf.global.noSelection{/lang}</option>
-								{foreach from=$pageList item='item'}
-									<option value="{$item->pageID}" {if $item->pageID == $parentID}selected="selected"{/if} data-alias="{$item->alias}" >{$item->title|language}</option>
-								{/foreach}
-							</select>
-						</dd>
-					</dl>
-				{/if}
-
 				<dl{if $errorField == 'title'} class="formError"{/if}>
-					<dt><label for="title">{lang}cms.acp.page.general.title{/lang}</label></dt>
+					<dt><label for="title">{lang}cms.acp.page.title{/lang}</label></dt>
 					<dd>
 						<input type="text" id="title" name="title" value="{$i18nPlainValues['title']}" class="long" required="required" />
 						{if $errorField == 'title'}
@@ -149,6 +135,21 @@
 						{include file='multipleLanguageInputJavascript' elementIdentifier='description' forceSelection=false}
 					</dd>
 				</dl>
+
+				<dl{if $errorField == 'menuItem'} class="formError"{/if}>
+					<dt class="reversed"><label for="menuItem">{lang}cms.acp.page.general.menuItem{/lang}</label></dt>
+					<dd>
+						<input type="checkbox" name="menuItem" id="menuItem" value="1"{if $menu == 1} checked="checked"{/if} />
+						{if $errorField == 'menuItem'}
+							<small class="innerError">
+								{lang}cms.acp.page.general.menuItem.error.{@$errorType}{/lang}
+							</small>
+						{/if}
+						<small>{lang}cms.acp.page.general.menuItem.description{/lang}</small>
+					</dd>
+				</dl>
+
+				{event name='dataFields'}
 			</fieldset>
 
 			<fieldset>
@@ -187,87 +188,96 @@
 					<dt><label for="robots">{lang}cms.acp.page.meta.robots{/lang}</label></dt>
 					<dd>
 						<select id="robots" name="robots">
-							<option value="index,follow" {if $robots =="index,follow"}selected="selected"{/if}>{lang}cms.acp.page.meta.robots.indexfollow{/lang}</option>
-							<option value="index,nofollow" {if $robots =="index,nofollow"}selected="selected"{/if}>{lang}cms.acp.page.meta.robots.indexnofollow{/lang}</option>
-							<option value="noindex,follow" {if $robots =="noindex,follow"}selected="selected"{/if}>{lang}cms.acp.page.meta.robots.noindexfollow{/lang}</option>
-							<option value="noindex,nofollow" {if $robots =="noindex,nofollow"}selected="selected"{/if}>{lang}cms.acp.page.meta.robots.noindexnofollow{/lang}</option>
+							<option value="index,follow"{if $robots =="index,follow"} selected="selected"{/if}>{lang}cms.acp.page.meta.robots.indexfollow{/lang}</option>
+							<option value="index,nofollow"{if $robots =="index,nofollow"} selected="selected"{/if}>{lang}cms.acp.page.meta.robots.indexnofollow{/lang}</option>
+							<option value="noindex,follow"{if $robots =="noindex,follow"} selected="selected"{/if}>{lang}cms.acp.page.meta.robots.noindexfollow{/lang}</option>
+							<option value="noindex,nofollow"{if $robots =="noindex,nofollow"} selected="selected"{/if}>{lang}cms.acp.page.meta.robots.noindexnofollow{/lang}</option>
 						</select>
 					</dd>
 				</dl>
+
+				{event name='metaFields'}
 			</fieldset>
 
 			<fieldset>
-				<legend>{lang}cms.acp.page.visibility{/lang}</legend>
+				<legend>{lang}cms.acp.page.position{/lang}</legend>
 
-				<dl{if $errorField == 'invisible'} class="formError"{/if}>
-					<dt class="reversed"><label for="invisible">{lang}cms.acp.page.optional.invisible{/lang}</label></dt>
-					<dd>
-						<input type="checkbox" name="invisible" id="invisible" value="1" {if $invisible == 1}checked="checked"{/if} />
-					</dd>
-				</dl>
-
-				<dl{if $errorField == 'menuItem'} class="formError"{/if}>
-					<dt class="reversed"><label for="menuItem">{lang}cms.acp.page.optional.menuItem{/lang}</label></dt>
-					<dd>
-						<input type="checkbox" name="menuItem" id="menuItem" value="1" {if $menu == 1}checked="checked"{/if} />
-						{if $errorField == 'menuItem'}
-							<small class="innerError">
-								{lang}cms.acp.page.menuItem.error.{@$errorType}{/lang}
-							</small>
-						{/if}
-					</dd>
-				</dl>
-
-				<dl{if $errorField == 'availableDuringOfflineMode'} class="formError"{/if}>
-					<dt class="reversed"><label for="availableDuringOfflineMode">{lang}cms.acp.page.optional.availableDuringOfflineMode{/lang}</label></dt>
-					<dd>
-						<input type="checkbox" name="availableDuringOfflineMode" id="availableDuringOfflineMode" value="1" {if $availableDuringOfflineMode == 1}checked="checked"{/if} />
-					</dd>
-				</dl>
+				{if $pageList != null}
+					<dl{if $errorField == 'parentID'} class="formError"{/if}>
+						<dt><label for="parentID">{lang}cms.acp.page.general.parentID{/lang}</label></dt>
+						<dd>
+							<select id="parentID" name="parentID">
+								<option value="0" {if parentID == 0} selected="selected"{/if} data-alias="">{lang}wcf.global.noSelection{/lang}</option>
+								{foreach from=$pageList item='item'}
+									<option value="{$item->pageID}" {if $item->pageID == $parentID}selected="selected"{/if} data-alias="{$item->alias}" >{$item->title|language}</option>
+								{/foreach}
+							</select>
+						</dd>
+					</dl>
+				{/if}
 
 				<dl{if $errorField == 'showOrder'} class="formError"{/if}>
-					<dt><label for="showOrder">{lang}cms.acp.page.optional.showOrder{/lang}</label></dt>
+					<dt><label for="showOrder">{lang}cms.acp.page.position{/lang}</label></dt>
 					<dd>
-						<input type="number" id="showOrder" name="showOrder" value="{$showOrder}" />
+						<input type="number" id="showOrder" name="showOrder" value="{$showOrder}" class="tiny" min="0" />
 						{if $errorField == 'showOrder'}
 							<small class="innerError">
-								{lang}cms.acp.page.showOrder.error.{@$errorType}{/lang}
+								{lang}cms.acp.page.position.error.{@$errorType}{/lang}
 							</small>
 						{/if}
+						<small>{lang}cms.acp.page.position.description{/lang}</small>
 					</dd>
 				</dl>
+
+				<dl{if $errorField == 'invisible'} class="formError"{/if}>
+					<dt class="reversed"><label for="invisible">{lang}cms.acp.page.position.invisible{/lang}</label></dt>
+					<dd>
+						<input type="checkbox" name="invisible" id="invisible" value="1"{if $invisible} checked="checked"{/if} />
+						<small>{lang}cms.acp.page.position.invisible.description{/lang}</small>
+					</dd>
+				</dl>
+
+				{event name='positionFields'}
 			</fieldset>
 
 			<fieldset>
-				<legend>{lang}cms.acp.page.optional{/lang}</legend>
+				<legend>{lang}cms.acp.page.settings{/lang}</legend>
 
 				<dl{if $errorField == 'showSidebar'} class="formError"{/if}>
-					<dt class="reversed"><label for="showSidebar">{lang}cms.acp.page.optional.showSidebar{/lang}</label></dt>
+					<dt class="reversed"><label for="showSidebar">{lang}cms.acp.page.settings.showSidebar{/lang}</label></dt>
 					<dd>
-						<input type="checkbox" name="showSidebar" id="showSidebar" value="1" {if $showSidebar == 1}checked="checked"{/if} />
+						<input type="checkbox" name="showSidebar" id="showSidebar" value="1"{if $showSidebar} checked="checked"{/if} />
 					</dd>
 				</dl>
 
 				<dl{if $errorField == 'sidebarOrientation'} class="formError"{/if}>
-					<dt><label for="sidebarOrientation">{lang}cms.acp.page.optional.sidebarOrientation{/lang}</label></dt>
+					<dt><label for="sidebarOrientation">{lang}cms.acp.page.settings.sidebarOrientation{/lang}</label></dt>
 					<dd>
 						<select id="sidebarOrientation" name="sidebarOrientation">
-							<option value="right" {if $sidebarOrientation =="right"}selected="selected"{/if}>{lang}cms.acp.page.sidebarOrientation.right{/lang}</option>
-							<option value="left" {if $sidebarOrientation =="left"}selected="selected"{/if}>{lang}cms.acp.page.sidebarOrientation.left{/lang}</option>
+							<option value="right"{if $sidebarOrientation =="right"} selected="selected"{/if}>{lang}cms.acp.page.settings.sidebarOrientation.right{/lang}</option>
+							<option value="left"{if $sidebarOrientation =="left"} selected="selected"{/if}>{lang}cms.acp.page.settings.sidebarOrientation.left{/lang}</option>
 						</select>
 					</dd>
 				</dl>
 
 				<dl{if $errorField == 'isCommentable'} class="formError"{/if}>
-					<dt class="reversed"><label for="isCommentable">{lang}cms.acp.page.optional.isCommentable{/lang}</label></dt>
+					<dt class="reversed"><label for="isCommentable">{lang}cms.acp.page.settings.isCommentable{/lang}</label></dt>
 					<dd>
-						<input type="checkbox" name="isCommentable" id="isCommentable" value="1" {if $isCommentable == 1}checked="checked"{/if} />
+						<input type="checkbox" name="isCommentable" id="isCommentable" value="1"{if $isCommentable == 1} checked="checked"{/if} />
+						<small>{lang}cms.acp.page.settings.isCommentable.description{/lang}</small>
+					</dd>
+				</dl>
+
+				<dl{if $errorField == 'availableDuringOfflineMode'} class="formError"{/if}>
+					<dt class="reversed"><label for="availableDuringOfflineMode">{lang}cms.acp.page.settings.availableDuringOfflineMode{/lang}</label></dt>
+					<dd>
+						<input type="checkbox" name="availableDuringOfflineMode" id="availableDuringOfflineMode" value="1"{if $availableDuringOfflineMode} checked="checked"{/if} />
 					</dd>
 				</dl>
 
 				{if $layoutList != null}
 					<dl{if $errorField == 'layoutID'} class="formError"{/if}>
-						<dt><label for="layoutID">{lang}cms.acp.page.optional.layoutID{/lang}</label></dt>
+						<dt><label for="layoutID">{lang}cms.acp.page.settings.layoutID{/lang}</label></dt>
 						<dd>
 							<select id="layoutID" name="layoutID">
 								<option value="0" {if layoutID == 0} selected="selected"{/if}></option>

--- a/language/de.xml
+++ b/language/de.xml
@@ -1,78 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<language xmlns="http://www.woltlab.com" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.woltlab.com http://www.woltlab.com/XSD/maelstrom/language.xsd"
-	languagename="Deutsch" countrycode="de" languagecode="de">
-	<category name="cms.acp.menu">
-		<item name="cms.acp.menu.link.cms"><![CDATA[CMS]]></item>
-		<item name="cms.acp.menu.link.cms.page.overview"><![CDATA[Übersicht]]></item>
-		<item name="cms.acp.menu.link.cms.page.list"><![CDATA[Seiten auflisten]]></item>
-		<item name="cms.acp.menu.link.cms.page.add"><![CDATA[Seite hinzufügen]]></item>
-		<item name="cms.acp.menu.link.cms.content.list"><![CDATA[Inhalte auflisten]]></item>
-		<item name="cms.acp.menu.link.cms.content.add"><![CDATA[Inhalt hinzufügen]]></item>
-		<item name="cms.acp.menu.link.cms.content.section.list"><![CDATA[Inhaltsabschnitte auflisten]]></item>
-		<item name="cms.acp.menu.link.cms.stylesheet.list"><![CDATA[Stylesheets auflisten]]></item>
-		<item name="cms.acp.menu.link.cms.stylesheet.add"><![CDATA[Stylesheet hinzufügen]]></item>
-		<item name="cms.acp.menu.link.cms.layout.list"><![CDATA[Layouts auflisten]]></item>
-		<item name="cms.acp.menu.link.cms.layout.add"><![CDATA[Layout hinzufügen]]></item>
-		<item name="cms.acp.menu.link.cms.file.management"><![CDATA[Dateiverwaltung]]></item>
-		<item name="cms.acp.menu.link.cms.news.category.add"><![CDATA[Kategorie hinzufügen]]></item>
-		<item name="cms.acp.menu.link.cms.news.category.list"><![CDATA[Kategorien auflisten]]></item>
-		<item name="cms.acp.menu.link.cms.style"><![CDATA[Darstellungsoptionen]]></item>
-		<item name="cms.acp.menu.link.cms.content"><![CDATA[Seiten verwalten]]></item>
-		<item name="cms.acp.menu.link.cms.news"><![CDATA[Nachrichten]]></item>
-		<item name="cms.acp.menu.link.cms.module.add"><![CDATA[Modul hinzufügen]]></item>
-		<item name="cms.acp.menu.link.cms.module.list"><![CDATA[Module auflisten]]></item>
-		<item name="cms.acp.menu.link.cms.dashboard"><![CDATA[Dashboard]]></item>
-		<item name="cms.acp.menu.link.cms.page.dashboard"><![CDATA[Dashboard]]></item>
-		<item name="cms.acp.menu.link.cms.page.statistics"><![CDATA[Statistiken]]></item>
-		<item name="cms.acp.menu.link.cms.media"><![CDATA[Medien]]></item>
-		<item name="cms.acp.menu.link.cms.news.image.list"><![CDATA[Nachrichtenbilder auflisten]]></item>
-		<item name="cms.acp.menu.link.cms.news.image.add"><![CDATA[Nachrichtenbilder hinzufügen]]></item>
-	</category>
-
-	<category name="cms.acp">
-		<item name="cms.acp.page.overview"><![CDATA[Übersicht]]></item>
-		<item name="cms.acp.page.list"><![CDATA[Seiten]]></item>
-		<item name="cms.acp.page.add"><![CDATA[Seite hinzufügen]]></item>
-		<item name="cms.acp.page.edit"><![CDATA[Seite bearbeiten]]></item>
-		<item name="cms.acp.page.title"><![CDATA[Seitentitel]]></item>
-		<item name="cms.acp.page.content.list"><![CDATA[Inhalte von '{$page->title|language}' auflisten]]></item>
-		<item name="cms.acp.page.description"><![CDATA[Beschreibung]]></item>
-		<item name="cms.acp.page.setAsHome"><![CDATA[Als Startseite setzen]]></item>
-		<item name="cms.acp.page.setAsHome.confirmMessage"><![CDATA[Möchten sie diese Seite als Startseite des CMS festlegen? Sollte es bereits einen Menüpunkt für diese Seite geben, so wird dieser entfernt.]]></item>
-		<item name="cms.acp.page.homePage"><![CDATA[Startseite]]></item>
-		<item name="cms.acp.page.general"><![CDATA[Allgemein]]></item>
-		<item name="cms.acp.page.general.parentID"><![CDATA[Übergeordnete Seite]]></item>
-		<item name="cms.acp.page.general.title"><![CDATA[Seitentitel]]></item>
-		<item name="cms.acp.page.general.alias"><![CDATA[URL-Alias]]></item>
-		<item name="cms.acp.page.alias.error.given"><![CDATA[Ein gleichnamiger Alias existiert bereits.]]></item>
-		<item name="cms.acp.page.alias.error.invalid"><![CDATA[Kein gültiger Alias.]]></item>
-		<item name="cms.acp.page.general.alias.preview"><![CDATA[Link-Vorschau:]]></item>
-		<item name="cms.acp.page.general.alias.description"><![CDATA[Der sogenannte Alias ist eine Art Abkürzung, die später der Link zu dieser Seite sein wird. Ein Alias darf ausschließlich aus Kleinbuchstaben von a-z, Ziffern von 0-9 und Bindestrichen bestehen.]]></item>
-		<item name="cms.acp.page.general.description"><![CDATA[Beschreibung]]></item>
-		<item name="cms.acp.page.meta"><![CDATA[Meta-Informationen]]></item>
-		<item name="cms.acp.page.meta.metaDescription"><![CDATA[Meta-Beschreibung]]></item>
-		<item name="cms.acp.page.metaDescription.description"><![CDATA[Das meta-Element Attribut “description” wird laut Google nicht zur Berechnung des Rankings ausgewertet, ist aber maßgeblich für die CTR (Click-Through-Rate) von Usern ausschlaggebend und sollte demnach Beachtung finden.]]></item>
-		<item name="cms.acp.page.meta.metaKeywords"><![CDATA[Meta-Schlüsselwörter]]></item>
-		<item name="cms.acp.page.meta.robots"><![CDATA[Anweisung für Suchmaschinenroboter]]></item>
-		<item name="cms.acp.page.meta.robots.indexfollow"><![CDATA[Seite indizieren und Links folgen (Empfohlen)]]></item>
-		<item name="cms.acp.page.meta.robots.indexnofollow"><![CDATA[Seite indizieren und Links nicht folgen]]></item>
-		<item name="cms.acp.page.meta.robots.noindexfollow"><![CDATA[Seite nicht indizieren, aber Links folgen]]></item>
-		<item name="cms.acp.page.meta.robots.noindexnofollow"><![CDATA[Seite nicht indizieren und keinem Link folgen]]></item>
-		<item name="cms.acp.page.optional"><![CDATA[Einstellungen]]></item>
-		<item name="cms.acp.page.optional.availableDuringOfflineMode"><![CDATA[Seite ist im Wartungsmodus verfügbar]]></item>
-		<item name="cms.acp.page.visibility"><![CDATA[Sichtbarkeit]]></item>
-		<item name="cms.acp.page.optional.invisible"><![CDATA[Seite ist unsichtbar]]></item>
-		<item name="cms.acp.page.optional.showOrder"><![CDATA[Sortierungsreihenfolge]]></item>
-		<item name="cms.acp.page.optional.menuItem"><![CDATA[Menüitem erstellen]]></item>
-		<item name="cms.acp.page.optional.showSidebar"><![CDATA[Globale Seitenleiste anzeigen]]></item>
-		<item name="cms.acp.page.optional.sidebarOrientation"><![CDATA[Ausrichtung der Seitenleiste]]></item>
-		<item name="cms.acp.page.sidebarOrientation.right"><![CDATA[Rechte Seitenleiste]]></item>
-		<item name="cms.acp.page.sidebarOrientation.left"><![CDATA[Linke Seitenleiste]]></item>
-		<item name="cms.acp.page.content.add"><![CDATA[Inhalte zu '{$page->title|language}' hinzufügen]]></item>
-		<item name="cms.acp.page.optional.isCommentable"><![CDATA[Kommentare erlauben]]></item>
-		<item name="cms.acp.page.optional.layoutID"><![CDATA[Layout auswählen]]></item>
-		<item name="cms.acp.page.menuItem.error.exists"><![CDATA[Es existiert bereits ein Menüpunkt mit gleichem Bezeichner. Aus technischen Gründen ist es nicht möglich einen weiteren Menüpunkt zu erstellen.]]></item>
+<language xmlns="http://www.woltlab.com" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.woltlab.com http://www.woltlab.com/XSD/maelstrom/language.xsd" languagecode="de">
+	<category name="cms.acp.content">
 		<item name="cms.acp.content.add"><![CDATA[Inhalt hinzufügen]]></item>
 		<item name="cms.acp.content.add.noPage"><![CDATA[Keine Seiten gefunden! Um einen Inhalt zu erstellen müssen Sie zuerst mindestens eine Seite erstellen.]]></item>
 		<item name="cms.acp.content.general"><![CDATA[Allgemein]]></item>
@@ -91,24 +19,17 @@
 		<item name="cms.acp.content.page.list"><![CDATA[Seite wählen...]]></item>
 		<item name="cms.acp.content.section.general"><![CDATA[Allgemeine Einstellungen]]></item>
 		<item name="cms.acp.content.section.general.objectType"><![CDATA[Inhaltstyp]]></item>
-		<item
-			name="cms.acp.content.section.type.de.codequake.cms.section.type.text"><![CDATA[Text]]></item>
-		<item
-			name="cms.acp.content.section.type.de.codequake.cms.section.type.headline"><![CDATA[Überschrift]]></item>
+		<item name="cms.acp.content.section.type.de.codequake.cms.section.type.text"><![CDATA[Text]]></item>
+		<item name="cms.acp.content.section.type.de.codequake.cms.section.type.headline"><![CDATA[Überschrift]]></item>
 		<item name="cms.acp.content.section.data"><![CDATA[Inhalt]]></item>
 		<item name="cms.acp.content.section.data.text"><![CDATA[Text]]></item>
 		<item name="cms.acp.content.section.data.headline"><![CDATA[Überschrift]]></item>
 		<item name="cms.acp.content.section.data.hyperlink"><![CDATA[Hyperlink]]></item>
-		<item
-			name="cms.acp.content.section.type.de.codequake.cms.section.type.file"><![CDATA[Datei]]></item>
-		<item
-			name="cms.acp.content.section.type.de.codequake.cms.section.type.image"><![CDATA[Bilder]]></item>
-		<item
-			name="cms.acp.content.section.type.de.codequake.cms.section.type.news"><![CDATA[Nachrichtenauflistung]]></item>
-		<item
-			name="cms.acp.content.section.type.de.codequake.cms.section.type.module"><![CDATA[Modul]]></item>
-		<item
-			name="cms.acp.content.section.type.de.codequake.cms.section.type.dashboard"><![CDATA[Dashboardbox]]></item>
+		<item name="cms.acp.content.section.type.de.codequake.cms.section.type.file"><![CDATA[Datei]]></item>
+		<item name="cms.acp.content.section.type.de.codequake.cms.section.type.image"><![CDATA[Bilder]]></item>
+		<item name="cms.acp.content.section.type.de.codequake.cms.section.type.news"><![CDATA[Nachrichtenauflistung]]></item>
+		<item name="cms.acp.content.section.type.de.codequake.cms.section.type.module"><![CDATA[Modul]]></item>
+		<item name="cms.acp.content.section.type.de.codequake.cms.section.type.dashboard"><![CDATA[Dashboardbox]]></item>
 		<item name="cms.acp.content.section.data.boxID"><![CDATA[Dashboardbox]]></item>
 		<item name="cms.acp.content.section.data.boxID.description"><![CDATA[Wählen Sie eine Dashboardbox. Die Auswahl passt sich der Ausrichtung des Inhaltsbereichs an.]]></item>
 		<item name="cms.acp.content.section.data.moduleID"><![CDATA[Modul auswählen]]></item>
@@ -152,60 +73,13 @@
 		<item name="cms.acp.content.section.data.type"><![CDATA[Typ]]></item>
 		<item name="cms.acp.content.section.data.button"><![CDATA[großer Button]]></item>
 		<item name="cms.acp.content.section.data.buttonsmall"><![CDATA[kleiner Button]]></item>
-		<item
-			name="cms.acp.content.section.type.de.codequake.cms.section.type.link"><![CDATA[Hyperlink/Button]]></item>
+		<item name="cms.acp.content.section.type.de.codequake.cms.section.type.link"><![CDATA[Hyperlink/Button]]></item>
 		<item name="cms.acp.content.section.data.type"><![CDATA[Typ]]></item>
-		<item name="cms.acp.page.userPermissions"><![CDATA[Berechtigungen]]></item>
-		<item name="cms.acp.module.list"><![CDATA[Module auflisten]]></item>
-		<item name="cms.acp.module.add"><![CDATA[Modul hinzufügen]]></item>
-		<item name="cms.acp.module.edit"><![CDATA[Modul bearbeiten]]></item>
-		<item name="cms.acp.module.general"><![CDATA[Allgemeine Einstellungen]]></item>
-		<item name="cms.acp.module.php"><![CDATA[PHP-Quelltext]]></item>
-		<item name="cms.acp.module.php.description"><![CDATA[Hier können Sie PHP-Quelltext verwenden. <strong>Achtung</strong>: PHP-Fehler können dazu führen, dass Seiten nicht korrekt dargestellt werden.]]></item>
-		<item name="cms.acp.module.tpl"><![CDATA[Template-Quelltext]]></item>
-		<item name="cms.acp.module.tpl.description"><![CDATA[Hier können Sie Template-Quelltext verwenden (<a href="http://www.smarty.net/">Dokumentation</a>).]]></item>
-		<item name="cms.acp.module.title"><![CDATA[Titel]]></item>
-		<item name="cms.acp.stylesheet.list"><![CDATA[Stylesheets]]></item>
-		<item name="cms.acp.stylesheet.title"><![CDATA[Titel]]></item>
-		<item name="cms.acp.stylesheet.general"><![CDATA[Allgemeine Einstellungen]]></item>
-		<item name="cms.acp.stylesheet.add"><![CDATA[Stylesheet hinzufügen]]></item>
-		<item name="cms.acp.stylesheet.edit"><![CDATA[Stylesheet bearbeiten]]></item>
-		<item name="cms.acp.stylesheet.less"><![CDATA[CSS & Less]]></item>
-		<item name="cms.acp.stylesheet.less.description"><![CDATA[Die Eingabe kann vollständig aus CSS bestehen. Sie haben zusätzlich den Zugriff auf LESS und alle von Community Framework zur Verfügung gestellten Mixins.]]></item>
-		<item name="cms.acp.layout.list"><![CDATA[Layouts]]></item>
-		<item name="cms.acp.layout.edit"><![CDATA[Layout bearbeiten]]></item>
-		<item name="cms.acp.layout.title"><![CDATA[Titel]]></item>
-		<item name="cms.acp.layout.add"><![CDATA[Layout hinzufügen]]></item>
-		<item name="cms.acp.layout.add.noSheet"><![CDATA[Um ein Layout zu erstellen müssen Sie zuerst mindestens ein Stylesheet erstellen!]]></item>
-		<item name="cms.acp.layout.general"><![CDATA[Allgemeine Einstellungen]]></item>
-		<item name="cms.acp.layout.options"><![CDATA[Optionen]]></item>
-		<item name="cms.acp.layout.stylesheets"><![CDATA[Stylesheets auswählen]]></item>
-		<item name="cms.acp.file.error.invalid"><![CDATA[Ungültige Dateiendung]]></item>
-		<item name="cms.acp.file.file"><![CDATA[Datei]]></item>
-		<item name="cms.acp.file.title"><![CDATA[Titel]]></item>
-		<item name="cms.acp.file.type"><![CDATA[Typ]]></item>
-		<item name="cms.acp.file.downloads"><![CDATA[Downloads]]></item>
-		<item name="cms.acp.file.list"><![CDATA[Dateien]]></item>
-		<item name="cms.acp.file.error.empty"><![CDATA[Bitte laden Sie eine gültige Datei hoch.]]></item>
-		<item name="cms.acp.file.management"><![CDATA[Dateiverwaltung]]></item>
-		<item name="cms.acp.file.details"><![CDATA[Informationen]]></item>
-		<item name="cms.acp.folder"><![CDATA[Ordner]]></item>
-		<item name="cms.acp.file.folderID"><![CDATA[Ordner]]></item>
-		<item name="cms.acp.folder.toRoot"><![CDATA[Zum Hauptverzeichnis wechseln]]></item>
-		<item name="cms.acp.folder.add"><![CDATA[Ordner erstellen]]></item>
-		<item name="cms.acp.folder.open"><![CDATA[Hier klicken um Dateien anzuzeigen]]></item>
-		<item name="cms.acp.folder.delete.sure"><![CDATA[Wollen Sie diesen Ordner und alle sich darin befindenden Dateien wirklich löschen?]]></item>
-		<item name="cms.acp.file.add"><![CDATA[Datei hochladen]]></item>
-		<item name="cms.acp.files.noItems"><![CDATA[Es sind keine Dateien und Ordner vorhanden.]]></item>
-		<item name="cms.acp.folder.error.exists"><![CDATA[Der Ordnername ist ungültig oder existiert bereits.]]></item>
-		<item name="cms.acp.file.folderID.root"><![CDATA[Hauptverzeichnis]]></item>
-		<item name="cms.acp.page.delete.sure"><![CDATA[Wollen Sie diese Seite und all ihre Inhalte wirklich löschen?]]></item>
 		<item name="cms.acp.content.delete.sure"><![CDATA[Wollen Sie diesen Inhalt und all seine Abschnitte wirklich löschen?]]></item>
 		<item name="cms.acp.content.section.delete.sure"><![CDATA[Wollen Sie diesen Abschnitt wirklich löschen?]]></item>
-		<item name="cms.acp.file.delete.sure"><![CDATA[Wollen Sie diese Datei wirklich löschen?]]></item>
-		<item name="cms.acp.module.delete.sure"><![CDATA[Wollen Sie dieses Modul wirklich löschen?]]></item>
-		<item name="cms.acp.stylesheet.delete.sure"><![CDATA[Wollen Sie dieses Stylesheet wirklich löschen?]]></item>
-		<item name="cms.acp.layout.delete.sure"><![CDATA[Wollen Sie dieses Layout wirklich löschen?]]></item>
+	</category>
+
+	<category name="cms.acp.dashboard">
 		<item name="cms.acp.dashboard"><![CDATA[Dashboard]]></item>
 		<item name="cms.acp.dashboard.lastWeeksVisitors"><![CDATA[Besucher der letzten Woche]]></item>
 		<item name="cms.acp.dashboard.all"><![CDATA[Alle Besucher]]></item>
@@ -216,13 +90,87 @@
 		<item name="cms.acp.dashboard.visitsYesterday"><![CDATA[Besuche gestern]]></item>
 		<item name="cms.acp.dashboard.visitsMonth"><![CDATA[Besuche diesen Monat]]></item>
 		<item name="cms.acp.dashboard.visitsAll"><![CDATA[Besuche gesamt]]></item>
-		<item name="cms.acp.stats"><![CDATA[Statistiken]]></item>
-		<item name="cms.acp.stats.vistors"><![CDATA[Besucher]]></item>
-		<item name="cms.acp.stats.browsers"><![CDATA[Browserfamilien]]></item>
-		<item name="cms.acp.stats.mostClicked"><![CDATA[Meistgeklickte Seiten]]></item>
-		<item name="cms.acp.stats.page"><![CDATA[Seite]]></item>
-		<item name="cms.acp.stats.clicks"><![CDATA[Clicks]]></item>
-		<item name="cms.acp.stats.vistors"><![CDATA[Aktuelle Besucher]]></item>
+	</category>
+
+	<category name="cms.acp.file">
+		<item name="cms.acp.file.error.invalid"><![CDATA[Ungültige Dateiendung]]></item>
+		<item name="cms.acp.file.file"><![CDATA[Datei]]></item>
+		<item name="cms.acp.file.title"><![CDATA[Titel]]></item>
+		<item name="cms.acp.file.type"><![CDATA[Typ]]></item>
+		<item name="cms.acp.file.downloads"><![CDATA[Downloads]]></item>
+		<item name="cms.acp.file.list"><![CDATA[Dateien]]></item>
+		<item name="cms.acp.file.error.empty"><![CDATA[Bitte laden Sie eine gültige Datei hoch.]]></item>
+		<item name="cms.acp.file.management"><![CDATA[Dateiverwaltung]]></item>
+		<item name="cms.acp.file.details"><![CDATA[Informationen]]></item>
+		<item name="cms.acp.file.folderID"><![CDATA[Ordner]]></item>
+		<item name="cms.acp.file.add"><![CDATA[Datei hochladen]]></item>
+		<item name="cms.acp.file.folderID.root"><![CDATA[Hauptverzeichnis]]></item>
+		<item name="cms.acp.file.delete.sure"><![CDATA[Wollen Sie diese Datei wirklich löschen?]]></item>
+	</category>
+
+	<category name="cms.acp.folder">
+		<item name="cms.acp.folder"><![CDATA[Ordner]]></item>
+		<item name="cms.acp.folder.toRoot"><![CDATA[Zum Hauptverzeichnis wechseln]]></item>
+		<item name="cms.acp.folder.add"><![CDATA[Ordner erstellen]]></item>
+		<item name="cms.acp.folder.open"><![CDATA[Hier klicken um Dateien anzuzeigen]]></item>
+		<item name="cms.acp.folder.delete.sure"><![CDATA[Wollen Sie diesen Ordner und alle sich darin befindenden Dateien wirklich löschen?]]></item>
+		<item name="cms.acp.folder.error.exists"><![CDATA[Der Ordnername ist ungültig oder existiert bereits.]]></item>
+	</category>
+
+	<category name="cms.acp.layout">
+		<item name="cms.acp.layout.list"><![CDATA[Layouts]]></item>
+		<item name="cms.acp.layout.edit"><![CDATA[Layout bearbeiten]]></item>
+		<item name="cms.acp.layout.title"><![CDATA[Titel]]></item>
+		<item name="cms.acp.layout.add"><![CDATA[Layout hinzufügen]]></item>
+		<item name="cms.acp.layout.add.noSheet"><![CDATA[Um ein Layout zu erstellen müssen Sie zuerst mindestens ein Stylesheet erstellen!]]></item>
+		<item name="cms.acp.layout.general"><![CDATA[Allgemeine Einstellungen]]></item>
+		<item name="cms.acp.layout.options"><![CDATA[Optionen]]></item>
+		<item name="cms.acp.layout.stylesheets"><![CDATA[Stylesheets auswählen]]></item>
+		<item name="cms.acp.layout.delete.sure"><![CDATA[Wollen Sie dieses Layout wirklich löschen?]]></item>
+	</category>
+
+	<category name="cms.acp.menu">
+		<item name="cms.acp.menu.link.cms"><![CDATA[CMS]]></item>
+		<item name="cms.acp.menu.link.cms.page.overview"><![CDATA[Übersicht]]></item>
+		<item name="cms.acp.menu.link.cms.page.list"><![CDATA[Seiten auflisten]]></item>
+		<item name="cms.acp.menu.link.cms.page.add"><![CDATA[Seite hinzufügen]]></item>
+		<item name="cms.acp.menu.link.cms.content.list"><![CDATA[Inhalte auflisten]]></item>
+		<item name="cms.acp.menu.link.cms.content.add"><![CDATA[Inhalt hinzufügen]]></item>
+		<item name="cms.acp.menu.link.cms.content.section.list"><![CDATA[Inhaltsabschnitte auflisten]]></item>
+		<item name="cms.acp.menu.link.cms.stylesheet.list"><![CDATA[Stylesheets auflisten]]></item>
+		<item name="cms.acp.menu.link.cms.stylesheet.add"><![CDATA[Stylesheet hinzufügen]]></item>
+		<item name="cms.acp.menu.link.cms.layout.list"><![CDATA[Layouts auflisten]]></item>
+		<item name="cms.acp.menu.link.cms.layout.add"><![CDATA[Layout hinzufügen]]></item>
+		<item name="cms.acp.menu.link.cms.file.management"><![CDATA[Dateiverwaltung]]></item>
+		<item name="cms.acp.menu.link.cms.news.category.add"><![CDATA[Kategorie hinzufügen]]></item>
+		<item name="cms.acp.menu.link.cms.news.category.list"><![CDATA[Kategorien auflisten]]></item>
+		<item name="cms.acp.menu.link.cms.style"><![CDATA[Darstellungsoptionen]]></item>
+		<item name="cms.acp.menu.link.cms.content"><![CDATA[Seiten verwalten]]></item>
+		<item name="cms.acp.menu.link.cms.news"><![CDATA[Nachrichten]]></item>
+		<item name="cms.acp.menu.link.cms.module.add"><![CDATA[Modul hinzufügen]]></item>
+		<item name="cms.acp.menu.link.cms.module.list"><![CDATA[Module auflisten]]></item>
+		<item name="cms.acp.menu.link.cms.dashboard"><![CDATA[Dashboard]]></item>
+		<item name="cms.acp.menu.link.cms.page.dashboard"><![CDATA[Dashboard]]></item>
+		<item name="cms.acp.menu.link.cms.page.statistics"><![CDATA[Statistiken]]></item>
+		<item name="cms.acp.menu.link.cms.media"><![CDATA[Medien]]></item>
+		<item name="cms.acp.menu.link.cms.news.image.list"><![CDATA[Nachrichtenbilder auflisten]]></item>
+		<item name="cms.acp.menu.link.cms.news.image.add"><![CDATA[Nachrichtenbilder hinzufügen]]></item>
+	</category>
+
+	<category name="cms.acp.module">
+		<item name="cms.acp.module.list"><![CDATA[Module auflisten]]></item>
+		<item name="cms.acp.module.add"><![CDATA[Modul hinzufügen]]></item>
+		<item name="cms.acp.module.edit"><![CDATA[Modul bearbeiten]]></item>
+		<item name="cms.acp.module.general"><![CDATA[Allgemeine Einstellungen]]></item>
+		<item name="cms.acp.module.php"><![CDATA[PHP-Quelltext]]></item>
+		<item name="cms.acp.module.php.description"><![CDATA[Hier können Sie PHP-Quelltext verwenden. <strong>Achtung</strong>: PHP-Fehler können dazu führen, dass Seiten nicht korrekt dargestellt werden.]]></item>
+		<item name="cms.acp.module.tpl"><![CDATA[Template-Quelltext]]></item>
+		<item name="cms.acp.module.tpl.description"><![CDATA[Hier können Sie Template-Quelltext verwenden (<a href="http://www.smarty.net/">Dokumentation</a>).]]></item>
+		<item name="cms.acp.module.title"><![CDATA[Titel]]></item>
+		<item name="cms.acp.module.delete.sure"><![CDATA[Wollen Sie dieses Modul wirklich löschen?]]></item>
+	</category>
+
+	<category name="cms.acp.news">
 		<item name="cms.acp.news.image.data"><![CDATA[Daten]]></item>
 		<item name="cms.acp.news.image.title"><![CDATA[Titel]]></item>
 		<item name="cms.acp.news.image"><![CDATA[Nachrichtenbild]]></item>
@@ -230,6 +178,77 @@
 		<item name="cms.acp.news.image.list"><![CDATA[Nachrichtenbilder]]></item>
 		<item name="cms.acp.news.image.title"><![CDATA[Titel]]></item>
 		<item name="cms.acp.news.image"><![CDATA[Vorschaubild]]></item>
+	</category>
+
+	<category name="cms.acp.page">
+		<item name="cms.acp.page.overview"><![CDATA[Übersicht]]></item>
+		<item name="cms.acp.page.list"><![CDATA[Seiten]]></item>
+		<item name="cms.acp.page.add"><![CDATA[Seite hinzufügen]]></item>
+		<item name="cms.acp.page.edit"><![CDATA[Seite bearbeiten]]></item>
+		<item name="cms.acp.page.title"><![CDATA[Seitentitel]]></item>
+		<item name="cms.acp.page.content.list"><![CDATA[Inhalte von '{$page->title|language}' auflisten]]></item>
+		<item name="cms.acp.page.description"><![CDATA[Beschreibung]]></item>
+		<item name="cms.acp.page.setAsHome"><![CDATA[Als Startseite setzen]]></item>
+		<item name="cms.acp.page.setAsHome.confirmMessage"><![CDATA[Möchten sie diese Seite als Startseite des CMS festlegen? Sollte es bereits einen Menüpunkt für diese Seite geben, so wird dieser entfernt.]]></item>
+		<item name="cms.acp.page.homePage"><![CDATA[Startseite]]></item>
+		<item name="cms.acp.page.general"><![CDATA[Allgemein]]></item>
+		<item name="cms.acp.page.general.parentID"><![CDATA[Übergeordnete Seite]]></item>
+		<item name="cms.acp.page.general.alias"><![CDATA[URL-Alias]]></item>
+		<item name="cms.acp.page.alias.error.given"><![CDATA[Ein gleichnamiger Alias existiert bereits.]]></item>
+		<item name="cms.acp.page.alias.error.invalid"><![CDATA[Kein gültiger Alias.]]></item>
+		<item name="cms.acp.page.general.alias.preview"><![CDATA[Link-Vorschau:]]></item>
+		<item name="cms.acp.page.general.alias.description"><![CDATA[Der sogenannte Alias ist eine Art Abkürzung, die später der Link zu dieser Seite sein wird. Ein Alias darf ausschließlich aus Kleinbuchstaben, Ziffern und Bindestrichen bestehen.]]></item>
+		<item name="cms.acp.page.general.description"><![CDATA[Beschreibung]]></item>
+		<item name="cms.acp.page.meta"><![CDATA[Meta-Informationen]]></item>
+		<item name="cms.acp.page.meta.metaDescription"><![CDATA[Meta-Beschreibung]]></item>
+		<item name="cms.acp.page.metaDescription.description"><![CDATA[Das meta-Element Attribut “description” wird laut Google nicht zur Berechnung des Rankings ausgewertet, ist aber maßgeblich für die CTR (Click-Through-Rate) von Usern ausschlaggebend und sollte demnach Beachtung finden.]]></item>
+		<item name="cms.acp.page.meta.metaKeywords"><![CDATA[Meta-Schlüsselwörter]]></item>
+		<item name="cms.acp.page.meta.robots"><![CDATA[Anweisung für Suchmaschinenroboter]]></item>
+		<item name="cms.acp.page.meta.robots.indexfollow"><![CDATA[Seite indizieren und Links folgen (Empfohlen)]]></item>
+		<item name="cms.acp.page.meta.robots.indexnofollow"><![CDATA[Seite indizieren und Links nicht folgen]]></item>
+		<item name="cms.acp.page.meta.robots.noindexfollow"><![CDATA[Seite nicht indizieren, aber Links folgen]]></item>
+		<item name="cms.acp.page.meta.robots.noindexnofollow"><![CDATA[Seite nicht indizieren und keinem Link folgen]]></item>
+		<item name="cms.acp.page.settings"><![CDATA[Einstellungen]]></item>
+		<item name="cms.acp.page.settings.availableDuringOfflineMode"><![CDATA[Seite ist im Wartungsmodus verfügbar]]></item>
+		<item name="cms.acp.page.visibility"><![CDATA[Sichtbarkeit]]></item>
+		<item name="cms.acp.page.general.menuItem"><![CDATA[Menüpunkt erstellen]]></item>
+		<item name="cms.acp.page.general.menuItem.description"><![CDATA[Sie können den erstellten Menüpunkt anschließend in der <a href="{link controller='PageMenuItemList'}{/link}">Hauptmenüverwaltung</a> verschieben oder bearbeiten.]]></item>
+		<item name="cms.acp.page.settings.showSidebar"><![CDATA[Globale Seitenleiste anzeigen]]></item>
+		<item name="cms.acp.page.settings.sidebarOrientation"><![CDATA[Ausrichtung der Seitenleiste]]></item>
+		<item name="cms.acp.page.settings.sidebarOrientation.right"><![CDATA[Rechte Seitenleiste]]></item>
+		<item name="cms.acp.page.settings.sidebarOrientation.left"><![CDATA[Linke Seitenleiste]]></item>
+		<item name="cms.acp.page.content.add"><![CDATA[Inhalte zu '{$page->title|language}' hinzufügen]]></item>
+		<item name="cms.acp.page.settings.isCommentable"><![CDATA[Kommentare aktivieren]]></item>
+		<item name="cms.acp.page.settings.isCommentable.description"><![CDATA[Erlaubt anderen Benutzern diese Seite zu kommentieren.]]></item>
+		<item name="cms.acp.page.settings.layoutID"><![CDATA[Layout auswählen]]></item>
+		<item name="cms.acp.page.menuItem.error.exists"><![CDATA[Es existiert bereits ein Menüpunkt mit gleichem Bezeichner. Aus technischen Gründen ist es nicht möglich einen weiteren Menüpunkt zu erstellen.]]></item>
+		<item name="cms.acp.page.position"><![CDATA[Position]]></item>
+		<item name="cms.acp.page.position.description"><![CDATA[Legt die Reihenfolge fest, in der die Seiten aufgelistet werden.]]></item>
+		<item name="cms.acp.page.position.invisible"><![CDATA[Seite verstecken]]></item>
+		<item name="cms.acp.page.position.invisible.description"><![CDATA[Diese Seite und ihre Unterseiten werden in allen Listen ausgeblendet, sind aber weiterhin mittels Direktlink aufrufbar.]]></item>
+		<item name="cms.acp.page.userPermissions"><![CDATA[Berechtigungen]]></item>
+		<item name="cms.acp.page.delete.sure"><![CDATA[Wollen Sie diese Seite und all ihre Inhalte wirklich löschen?]]></item>
+	</category>
+
+	<category name="cms.acp.stats">
+		<item name="cms.acp.stats"><![CDATA[Statistiken]]></item>
+		<item name="cms.acp.stats.vistors"><![CDATA[Besucher]]></item>
+		<item name="cms.acp.stats.browsers"><![CDATA[Browserfamilien]]></item>
+		<item name="cms.acp.stats.mostClicked"><![CDATA[Meistgeklickte Seiten]]></item>
+		<item name="cms.acp.stats.page"><![CDATA[Seite]]></item>
+		<item name="cms.acp.stats.clicks"><![CDATA[Clicks]]></item>
+		<item name="cms.acp.stats.vistors"><![CDATA[Aktuelle Besucher]]></item>
+	</category>
+
+	<category name="cms.acp.stylesheet">
+		<item name="cms.acp.stylesheet.list"><![CDATA[Stylesheets]]></item>
+		<item name="cms.acp.stylesheet.title"><![CDATA[Titel]]></item>
+		<item name="cms.acp.stylesheet.general"><![CDATA[Allgemeine Einstellungen]]></item>
+		<item name="cms.acp.stylesheet.add"><![CDATA[Stylesheet hinzufügen]]></item>
+		<item name="cms.acp.stylesheet.edit"><![CDATA[Stylesheet bearbeiten]]></item>
+		<item name="cms.acp.stylesheet.less"><![CDATA[CSS & Less]]></item>
+		<item name="cms.acp.stylesheet.less.description"><![CDATA[Die Eingabe kann vollständig aus CSS bestehen. Sie haben zusätzlich den Zugriff auf LESS und alle von Community Framework zur Verfügung gestellten Mixins.]]></item>
+		<item name="cms.acp.stylesheet.delete.sure"><![CDATA[Wollen Sie dieses Stylesheet wirklich löschen?]]></item>
 	</category>
 
 	<category name="cms.page">
@@ -375,8 +394,7 @@
 		<item name="wcf.acp.group.option.admin.cms.content.canUploadAttachment"><![CDATA[Kann Dateien anhängen]]></item>
 		<item name="wcf.acp.group.option.admin.cms.content.attachmentMaxSize"><![CDATA[Maximale Dateianhangsgröße]]></item>
 		<item name="wcf.acp.group.option.admin.cms.content.maxAttachmentCount"><![CDATA[Maximale Anzahl an Dateianhängen pro Inhaltsabschnitt]]></item>
-		<item
-			name="wcf.acp.group.option.admin.cms.content.allowedAttachmentExtensions"><![CDATA[Erlaubte Dateiendungen]]></item>
+		<item name="wcf.acp.group.option.admin.cms.content.allowedAttachmentExtensions"><![CDATA[Erlaubte Dateiendungen]]></item>
 		<item name="wcf.acp.group.option.user.cms.news.canViewDelayedNews"><![CDATA[Kann Nachrichten sehen, die noch nicht veröffentlicht wurden]]></item>
 	</category>
 
@@ -389,8 +407,7 @@
 		<item name="wcf.acl.option.de.codequake.cms.category.news.canViewNews"><![CDATA[Kann Nachrichten sehen]]></item>
 		<item name="wcf.acl.option.de.codequake.cms.category.news.canAddNews"><![CDATA[Kann Nachrichten hinzufügen]]></item>
 		<item name="wcf.acl.option.de.codequake.cms.category.news.canModerateNews"><![CDATA[Nachrichten Moderationsrecht]]></item>
-		<item
-			name="wcf.acl.option.de.codequake.cms.category.news.canViewDelayedNews"><![CDATA[Kann Nachrichten sehen, die noch nicht veröffentlicht wurden]]></item>
+		<item name="wcf.acl.option.de.codequake.cms.category.news.canViewDelayedNews"><![CDATA[Kann Nachrichten sehen, die noch nicht veröffentlicht wurden]]></item>
 	</category>
 
 	<category name="wcf.acp.option">
@@ -431,21 +448,15 @@
 	</category>
 
 	<category name="wcf.user.recentActivity">
-		<item
-			name="wcf.user.recentActivity.de.codequake.cms.news.recentActivityEvent"><![CDATA[Nachricht]]></item>
-		<item
-			name="wcf.user.recentActivity.de.codequake.cms.page.comment.recentActivityEvent"><![CDATA[Kommentar (Seite)]]></item>
-		<item
-			name="wcf.user.recentActivity.de.codequake.cms.page.comment.response.recentActivityEvent"><![CDATA[Antwort (Seite)]]></item>
-		<item
-			name="wcf.user.recentActivity.de.codequake.cms.news.comment.recentActivityEvent"><![CDATA[Kommentar (Nachricht)]]></item>
-		<item
-			name="wcf.user.recentActivity.de.codequake.cms.news.comment.response.recentActivityEvent"><![CDATA[Antwort (Nachricht)]]></item>
+		<item name="wcf.user.recentActivity.de.codequake.cms.news.recentActivityEvent"><![CDATA[Nachricht]]></item>
+		<item name="wcf.user.recentActivity.de.codequake.cms.page.comment.recentActivityEvent"><![CDATA[Kommentar (Seite)]]></item>
+		<item name="wcf.user.recentActivity.de.codequake.cms.page.comment.response.recentActivityEvent"><![CDATA[Antwort (Seite)]]></item>
+		<item name="wcf.user.recentActivity.de.codequake.cms.news.comment.recentActivityEvent"><![CDATA[Kommentar (Nachricht)]]></item>
+		<item name="wcf.user.recentActivity.de.codequake.cms.news.comment.response.recentActivityEvent"><![CDATA[Antwort (Nachricht)]]></item>
 	</category>
 
 	<category name="wcf.user.activityPoint">
-		<item
-			name="wcf.user.activityPoint.objectType.de.codequake.cms.activityPointEvent.news"><![CDATA[Nachrichten]]></item>
+		<item name="wcf.user.activityPoint.objectType.de.codequake.cms.activityPointEvent.news"><![CDATA[Nachrichten]]></item>
 	</category>
 
 	<category name="wcf.tagging">
@@ -465,14 +476,10 @@
 
 	<category name="wcf.user.notification">
 		<item name="wcf.user.notification.de.codequake.cms"><![CDATA[CMS]]></item>
-		<item
-			name="wcf.user.notification.de.codequake.cms.news.comment.notification.comment"><![CDATA[Neuer Kommentar zu einer Ihrer Nachrichten]]></item>
-		<item
-			name="wcf.user.notification.de.codequake.cms.news.comment.response.notification.commentResponse"><![CDATA[Neue Antwort auf einen Kommentar von Ihnen zu einer Nachricht]]></item>
-		<item
-			name="wcf.user.notification.de.codequake.cms.news.comment.response.notification.commentResponseOwner"><![CDATA[Neue Antwort auf einen Kommentar zu einer Ihrer Nachrichten]]></item>
-		<item
-			name="wcf.user.notification.de.codequake.cms.page.comment.response.notification.commentResponse"><![CDATA[Neue Antwort auf einen Kommentar auf einer Seite]]></item>
+		<item name="wcf.user.notification.de.codequake.cms.news.comment.notification.comment"><![CDATA[Neuer Kommentar zu einer Ihrer Nachrichten]]></item>
+		<item name="wcf.user.notification.de.codequake.cms.news.comment.response.notification.commentResponse"><![CDATA[Neue Antwort auf einen Kommentar von Ihnen zu einer Nachricht]]></item>
+		<item name="wcf.user.notification.de.codequake.cms.news.comment.response.notification.commentResponseOwner"><![CDATA[Neue Antwort auf einen Kommentar zu einer Ihrer Nachrichten]]></item>
+		<item name="wcf.user.notification.de.codequake.cms.page.comment.response.notification.commentResponse"><![CDATA[Neue Antwort auf einen Kommentar auf einer Seite]]></item>
 	</category>
 
 	<category name="wcf.acp.dataImport">

--- a/language/en.xml
+++ b/language/en.xml
@@ -1,76 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<language xmlns="http://www.woltlab.com" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.woltlab.com http://www.woltlab.com/XSD/maelstrom/language.xsd"
-	languagecode="en">
-	<category name="cms.acp.menu">
-		<item name="cms.acp.menu.link.cms"><![CDATA[CMS]]></item>
-		<item name="cms.acp.menu.link.cms.page.overview"><![CDATA[Overview]]></item>
-		<item name="cms.acp.menu.link.cms.page.list"><![CDATA[List pages]]></item>
-		<item name="cms.acp.menu.link.cms.page.add"><![CDATA[Add page]]></item>
-		<item name="cms.acp.menu.link.cms.content.list"><![CDATA[List contents]]></item>
-		<item name="cms.acp.menu.link.cms.content.add"><![CDATA[Add content]]></item>
-		<item name="cms.acp.menu.link.cms.content.section.list"><![CDATA[List content sections]]></item>
-		<item name="cms.acp.menu.link.cms.stylesheet.list"><![CDATA[List stylesheets]]></item>
-		<item name="cms.acp.menu.link.cms.stylesheet.add"><![CDATA[Add stylesheet]]></item>
-		<item name="cms.acp.menu.link.cms.layout.list"><![CDATA[List layouts]]></item>
-		<item name="cms.acp.menu.link.cms.layout.add"><![CDATA[Add layout]]></item>
-		<item name="cms.acp.menu.link.cms.file.management"><![CDATA[Filemanagement]]></item>
-		<item name="cms.acp.menu.link.cms.news.category.add"><![CDATA[Add category]]></item>
-		<item name="cms.acp.menu.link.cms.news.category.list"><![CDATA[List categories]]></item>
-		<item name="cms.acp.menu.link.cms.style"><![CDATA[Displaymanagement]]></item>
-		<item name="cms.acp.menu.link.cms.content"><![CDATA[Pagemanagement]]></item>
-		<item name="cms.acp.menu.link.cms.news"><![CDATA[News]]></item>
-		<item name="cms.acp.menu.link.cms.module.add"><![CDATA[Add module]]></item>
-		<item name="cms.acp.menu.link.cms.module.list"><![CDATA[List modules]]></item>
-		<item name="cms.acp.menu.link.cms.dashboard"><![CDATA[Dashboard]]></item>
-		<item name="cms.acp.menu.link.cms.page.dashboard"><![CDATA[Dashboard]]></item>
-		<item name="cms.acp.menu.link.cms.page.statistics"><![CDATA[Statistics]]></item>
-		<item name="cms.acp.menu.link.cms.media"><![CDATA[Media]]></item>
-		<item name="cms.acp.menu.link.cms.news.image.list"><![CDATA[List news images]]></item>
-		<item name="cms.acp.menu.link.cms.news.image.add"><![CDATA[Add news image]]></item>
-	</category>
-
-	<category name="cms.acp">
-		<item name="cms.acp.page.list"><![CDATA[Pages]]></item>
-		<item name="cms.acp.page.add"><![CDATA[Add page]]></item>
-		<item name="cms.acp.page.edit"><![CDATA[Edit page]]></item>
-		<item name="cms.acp.page.title"><![CDATA[Pagetitle]]></item>
-		<item name="cms.acp.page.content.list"><![CDATA[List contents of '{$page->title|language}']]></item>
-		<item name="cms.acp.page.description"><![CDATA[Description]]></item>
-		<item name="cms.acp.page.setAsHome"><![CDATA[Set as startpage]]></item>
-		<item name="cms.acp.page.setAsHome.confirmMessage"><![CDATA[Do you want to set this page as your CMS Startpage? If there is a menu item for this page yet, it will be deleted.]]></item>
-		<item name="cms.acp.page.homePage"><![CDATA[Startpage]]></item>
-		<item name="cms.acp.page.general"><![CDATA[General]]></item>
-		<item name="cms.acp.page.general.parentID"><![CDATA[Parent page]]></item>
-		<item name="cms.acp.page.general.title"><![CDATA[Pagetitle]]></item>
-		<item name="cms.acp.page.general.alias"><![CDATA[URL-Alias]]></item>
-		<item name="cms.acp.page.alias.error.given"><![CDATA[Alias exists!]]></item>
-		<item name="cms.acp.page.alias.error.invalid"><![CDATA[Invalid Alias!]]></item>
-		<item name="cms.acp.page.general.alias.preview"><![CDATA[Link-Preview:]]></item>
-		<item name="cms.acp.page.general.alias.description"><![CDATA[The so called alias will be this page's link. It must not contain any other items than lowercase-letters from a to z. numbers from 0 to 9 and a hyphen.]]></item>
-		<item name="cms.acp.page.general.description"><![CDATA[Description]]></item>
-		<item name="cms.acp.page.overview"><![CDATA[Overview]]></item>
-		<item name="cms.acp.page.meta"><![CDATA[Metainfomation]]></item>
-		<item name="cms.acp.page.meta.metaDescription"><![CDATA[Meta-Description]]></item>
-		<item name="cms.acp.page.metaDescription.description"><![CDATA[The meta element "description" is neccessary for a good CTR (Click-Through-Rate).]]></item>
-		<item name="cms.acp.page.meta.metaKeywords"><![CDATA[Meta-Keywords]]></item>
-		<item name="cms.acp.page.meta.robots"><![CDATA[Meta-Robots]]></item>
-		<item name="cms.acp.page.meta.robots.indexfollow"><![CDATA[index, follow (default)]]></item>
-		<item name="cms.acp.page.meta.robots.indexnofollow"><![CDATA[index, no follow]]></item>
-		<item name="cms.acp.page.meta.robots.noindexfollow"><![CDATA[no index, follow]]></item>
-		<item name="cms.acp.page.meta.robots.noindexnofollow"><![CDATA[no index, no follow]]></item>
-		<item name="cms.acp.page.optional"><![CDATA[Optional]]></item>
-		<item name="cms.acp.page.optional.invisible"><![CDATA[Invisible]]></item>
-		<item name="cms.acp.page.optional.showOrder"><![CDATA[Sortorder]]></item>
-		<item name="cms.acp.page.optional.menuItem"><![CDATA[Add menu item]]></item>
-		<item name="cms.acp.page.optional.showSidebar"><![CDATA[Show sidebar]]></item>
-		<item name="cms.acp.page.optional.sidebarOrientation"><![CDATA[Sidebarorientation]]></item>
-		<item name="cms.acp.page.sidebarOrientation.right"><![CDATA[Right]]></item>
-		<item name="cms.acp.page.sidebarOrientation.left"><![CDATA[Left]]></item>
-		<item name="cms.acp.page.content.add"><![CDATA[Add contents to'{$page->title|language}']]></item>
-		<item name="cms.acp.page.optional.isCommentable"><![CDATA[Allow comments]]></item>
-		<item name="cms.acp.page.optional.layoutID"><![CDATA[Choose layout]]></item>
-		<item name="cms.acp.page.menuItem.error.exists"><![CDATA[A Menuitem with this values already exists. For technical reasons you cannnot create a new one.]]></item>
+<language xmlns="http://www.woltlab.com" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.woltlab.com http://www.woltlab.com/XSD/maelstrom/language.xsd" languagecode="en">
+	<category name="cms.acp.content">
 		<item name="cms.acp.content.add"><![CDATA[Add content]]></item>
 		<item name="cms.acp.content.add.noPage"><![CDATA[No pages found! To create contents you must add at least one page.]]></item>
 		<item name="cms.acp.content.general"><![CDATA[General]]></item>
@@ -89,24 +19,17 @@
 		<item name="cms.acp.content.page.list"><![CDATA[Choose a page...]]></item>
 		<item name="cms.acp.content.section.general"><![CDATA[General]]></item>
 		<item name="cms.acp.content.section.general.objectType"><![CDATA[Contenttype]]></item>
-		<item
-			name="cms.acp.content.section.type.de.codequake.cms.section.type.text"><![CDATA[Text]]></item>
-		<item
-			name="cms.acp.content.section.type.de.codequake.cms.section.type.headline"><![CDATA[Headline]]></item>
+		<item name="cms.acp.content.section.type.de.codequake.cms.section.type.text"><![CDATA[Text]]></item>
+		<item name="cms.acp.content.section.type.de.codequake.cms.section.type.headline"><![CDATA[Headline]]></item>
 		<item name="cms.acp.content.section.data"><![CDATA[Content]]></item>
 		<item name="cms.acp.content.section.data.text"><![CDATA[Text]]></item>
 		<item name="cms.acp.content.section.data.headline"><![CDATA[Headline]]></item>
 		<item name="cms.acp.content.section.data.hyperlink"><![CDATA[Hyperlink]]></item>
-		<item
-			name="cms.acp.content.section.type.de.codequake.cms.section.type.file"><![CDATA[File]]></item>
-		<item
-			name="cms.acp.content.section.type.de.codequake.cms.section.type.image"><![CDATA[Images]]></item>
-		<item
-			name="cms.acp.content.section.type.de.codequake.cms.section.type.news"><![CDATA[Newslist]]></item>
-		<item
-			name="cms.acp.content.section.type.de.codequake.cms.section.type.module"><![CDATA[Module]]></item>
-		<item
-			name="cms.acp.content.section.type.de.codequake.cms.section.type.dashboard"><![CDATA[Dashboardbox]]></item>
+		<item name="cms.acp.content.section.type.de.codequake.cms.section.type.file"><![CDATA[File]]></item>
+		<item name="cms.acp.content.section.type.de.codequake.cms.section.type.image"><![CDATA[Images]]></item>
+		<item name="cms.acp.content.section.type.de.codequake.cms.section.type.news"><![CDATA[Newslist]]></item>
+		<item name="cms.acp.content.section.type.de.codequake.cms.section.type.module"><![CDATA[Module]]></item>
+		<item name="cms.acp.content.section.type.de.codequake.cms.section.type.dashboard"><![CDATA[Dashboardbox]]></item>
 		<item name="cms.acp.content.section.data.boxID"><![CDATA[Dashboardbox]]></item>
 		<item name="cms.acp.content.section.data.boxID.description"><![CDATA[Choose a Dashboardbox. You can only choose boxes which match your contents position.]]></item>
 		<item name="cms.acp.content.section.data.moduleID"><![CDATA[Choose module]]></item>
@@ -142,8 +65,6 @@
 		<item name="cms.acp.content.position.body"><![CDATA[Body]]></item>
 		<item name="cms.acp.content.position.sidebar"><![CDATA[Sidebar]]></item>
 		<item name="cms.acp.content.optional"><![CDATA[Optional]]></item>
-		<item name="cms.acp.page.optional.availableDuringOfflineMode"><![CDATA[Page is visible during offline mode]]></item>
-		<item name="cms.acp.page.visibility"><![CDATA[Visibility]]></item>
 		<item name="cms.acp.content.optional.position"><![CDATA[Position]]></item>
 		<item name="cms.acp.content.optional.type"><![CDATA[Type]]></item>
 		<item name="cms.acp.content.optional.type.description"><![CDATA[Has no effect in sidebar]]></item>
@@ -153,60 +74,12 @@
 		<item name="cms.acp.content.section.data.type"><![CDATA[Type]]></item>
 		<item name="cms.acp.content.section.data.button"><![CDATA[big button]]></item>
 		<item name="cms.acp.content.section.data.buttonsmall"><![CDATA[small button]]></item>
-		<item
-			name="cms.acp.content.section.type.de.codequake.cms.section.type.link"><![CDATA[Hyperlink/Button]]></item>
-		<item name="cms.acp.page.userPermissions"><![CDATA[Permissions]]></item>
-		<item name="cms.acp.module.list"><![CDATA[List modules]]></item>
-		<item name="cms.acp.module.add"><![CDATA[Add module]]></item>
-		<item name="cms.acp.module.edit"><![CDATA[Edit module]]></item>
-		<item name="cms.acp.module.general"><![CDATA[General]]></item>
-		<item name="cms.acp.module.php"><![CDATA[PHP-Source]]></item>
-		<item name="cms.acp.module.php.description"><![CDATA[You can use PHP-Syntax here. <strong>Danger</strong>: PHP-Errors might cause a non functionally site.]]></item>
-		<item name="cms.acp.module.tpl"><![CDATA[Template-Source]]></item>
-		<item name="cms.acp.module.tpl.description"><![CDATA[You can use Smarty-Syntax here (<a href="http://www.smarty.net/">Documentation</a>).]]></item>
-		<item name="cms.acp.module.title"><![CDATA[Title]]></item>
-		<item name="cms.acp.stylesheet.list"><![CDATA[Stylesheets]]></item>
-		<item name="cms.acp.stylesheet.title"><![CDATA[Title]]></item>
-		<item name="cms.acp.stylesheet.general"><![CDATA[General]]></item>
-		<item name="cms.acp.stylesheet.add"><![CDATA[Add stylesheet]]></item>
-		<item name="cms.acp.stylesheet.edit"><![CDATA[Edit stylesheet]]></item>
-		<item name="cms.acp.stylesheet.less"><![CDATA[CSS & Less]]></item>
-		<item name="cms.acp.stylesheet.less.description"><![CDATA[]]>
-		</item>
-		<item name="cms.acp.layout.list"><![CDATA[Layouts]]></item>
-		<item name="cms.acp.layout.edit"><![CDATA[Edit layout]]></item>
-		<item name="cms.acp.layout.title"><![CDATA[Title]]></item>
-		<item name="cms.acp.layout.add"><![CDATA[Add layout]]></item>
-		<item name="cms.acp.layout.add.noSheet"><![CDATA[To create a layout you have to create at least one stylesheet!]]></item>
-		<item name="cms.acp.layout.general"><![CDATA[General]]></item>
-		<item name="cms.acp.layout.options"><![CDATA[Options]]></item>
-		<item name="cms.acp.layout.stylesheets"><![CDATA[Choose stylesheets]]></item>
-		<item name="cms.acp.file.error.invalid"><![CDATA[Invalid file]]></item>
-		<item name="cms.acp.file.file"><![CDATA[File]]></item>
-		<item name="cms.acp.file.title"><![CDATA[Title]]></item>
-		<item name="cms.acp.file.type"><![CDATA[Type]]></item>
-		<item name="cms.acp.file.downloads"><![CDATA[Downloads]]></item>
-		<item name="cms.acp.file.list"><![CDATA[Files]]></item>
-		<item name="cms.acp.file.management"><![CDATA[Filemanagement]]></item>
-		<item name="cms.acp.file.details"><![CDATA[Information]]></item>
-		<item name="cms.acp.files.noItems"><![CDATA[Currently there are no folders and files.]]></item>
-		<item name="cms.acp.folder.error.exists"><![CDATA[The folder name is invalid or given.]]></item>
-		<item name="cms.acp.folder.delete.sure"><![CDATA[Are you sure you want to delete this folder and all of its files?]]></item>
-		<item name="cms.acp.folder"><![CDATA[Folder]]></item>
-		<item name="cms.acp.file.folderID"><![CDATA[Folder]]></item>
-		<item name="cms.acp.folder.toRoot"><![CDATA[Got to root]]></item>
-		<item name="cms.acp.folder.add"><![CDATA[Create folder]]></item>
-		<item name="cms.acp.folder.open"><![CDATA[Click here to show files]]></item>
-		<item name="cms.acp.file.add"><![CDATA[Upload file]]></item>
-		<item name="cms.acp.file.folderID.root"><![CDATA[Root]]></item>
-		<item name="cms.acp.file.error.empty"><![CDATA[Please upload a file.]]></item>
-		<item name="cms.acp.page.delete.sure"><![CDATA[Are you sure you want to delete this page and all of its contents?]]></item>
+		<item name="cms.acp.content.section.type.de.codequake.cms.section.type.link"><![CDATA[Hyperlink/Button]]></item>
 		<item name="cms.acp.content.delete.sure"><![CDATA[Are you sure you want to delete this content and all of its sections?]]></item>
 		<item name="cms.acp.content.section.delete.sure"><![CDATA[Are you sure you want to delete this section?]]></item>
-		<item name="cms.acp.file.delete.sure"><![CDATA[Are you sure you want to delete this file?]]></item>
-		<item name="cms.acp.module.delete.sure"><![CDATA[Are you sure you want to delete this module?]]></item>
-		<item name="cms.acp.stylesheet.delete.sure"><![CDATA[Are you sure you want to delete this stylesheet?]]></item>
-		<item name="cms.acp.layout.delete.sure"><![CDATA[Are you sure you want to delete this layout?]]></item>
+	</category>
+
+	<category name="cms.acp.dashboard">
 		<item name="cms.acp.dashboard"><![CDATA[Dashboard]]></item>
 		<item name="cms.acp.dashboard.lastWeeksVisitors"><![CDATA[Visits last week]]></item>
 		<item name="cms.acp.dashboard.all"><![CDATA[All]]></item>
@@ -217,13 +90,87 @@
 		<item name="cms.acp.dashboard.visitsYesterday"><![CDATA[Visits yesterday]]></item>
 		<item name="cms.acp.dashboard.visitsMonth"><![CDATA[Visits this month]]></item>
 		<item name="cms.acp.dashboard.visitsAll"><![CDATA[Visits all time]]></item>
-		<item name="cms.acp.stats"><![CDATA[Statistics]]></item>
-		<item name="cms.acp.stats.vistors"><![CDATA[Visitors]]></item>
-		<item name="cms.acp.stats.browsers"><![CDATA[Browsers]]></item>
-		<item name="cms.acp.stats.mostClicked"><![CDATA[Most visited pages]]></item>
-		<item name="cms.acp.stats.page"><![CDATA[Page]]></item>
-		<item name="cms.acp.stats.clicks"><![CDATA[Clicks]]></item>
-		<item name="cms.acp.stats.vistors"><![CDATA[Current visitors]]></item>
+	</category>
+
+	<category name="cms.acp.file">
+		<item name="cms.acp.file.error.invalid"><![CDATA[Invalid file]]></item>
+		<item name="cms.acp.file.file"><![CDATA[File]]></item>
+		<item name="cms.acp.file.title"><![CDATA[Title]]></item>
+		<item name="cms.acp.file.type"><![CDATA[Type]]></item>
+		<item name="cms.acp.file.downloads"><![CDATA[Downloads]]></item>
+		<item name="cms.acp.file.list"><![CDATA[Files]]></item>
+		<item name="cms.acp.file.management"><![CDATA[Filemanagement]]></item>
+		<item name="cms.acp.file.details"><![CDATA[Information]]></item>
+		<item name="cms.acp.file.folderID"><![CDATA[Folder]]></item>
+		<item name="cms.acp.file.add"><![CDATA[Upload file]]></item>
+		<item name="cms.acp.file.folderID.root"><![CDATA[Root]]></item>
+		<item name="cms.acp.file.error.empty"><![CDATA[Please upload a file.]]></item>
+		<item name="cms.acp.file.delete.sure"><![CDATA[Are you sure you want to delete this file?]]></item>
+	</category>
+
+	<category name="cms.acp.folder">
+		<item name="cms.acp.folder.error.exists"><![CDATA[The folder name is invalid or given.]]></item>
+		<item name="cms.acp.folder.delete.sure"><![CDATA[Are you sure you want to delete this folder and all of its files?]]></item>
+		<item name="cms.acp.folder.toRoot"><![CDATA[Got to root]]></item>
+		<item name="cms.acp.folder.add"><![CDATA[Create folder]]></item>
+		<item name="cms.acp.folder.open"><![CDATA[Click here to show files]]></item>
+		<item name="cms.acp.folder"><![CDATA[Folder]]></item>
+	</category>
+
+	<category name="cms.acp.layout">
+		<item name="cms.acp.layout.list"><![CDATA[Layouts]]></item>
+		<item name="cms.acp.layout.edit"><![CDATA[Edit layout]]></item>
+		<item name="cms.acp.layout.title"><![CDATA[Title]]></item>
+		<item name="cms.acp.layout.add"><![CDATA[Add layout]]></item>
+		<item name="cms.acp.layout.add.noSheet"><![CDATA[To create a layout you have to create at least one stylesheet!]]></item>
+		<item name="cms.acp.layout.general"><![CDATA[General]]></item>
+		<item name="cms.acp.layout.options"><![CDATA[Options]]></item>
+		<item name="cms.acp.layout.stylesheets"><![CDATA[Choose stylesheets]]></item>
+		<item name="cms.acp.layout.delete.sure"><![CDATA[Are you sure you want to delete this layout?]]></item>
+	</category>
+
+	<category name="cms.acp.menu">
+		<item name="cms.acp.menu.link.cms"><![CDATA[CMS]]></item>
+		<item name="cms.acp.menu.link.cms.page.overview"><![CDATA[Overview]]></item>
+		<item name="cms.acp.menu.link.cms.page.list"><![CDATA[List pages]]></item>
+		<item name="cms.acp.menu.link.cms.page.add"><![CDATA[Add page]]></item>
+		<item name="cms.acp.menu.link.cms.content.list"><![CDATA[List contents]]></item>
+		<item name="cms.acp.menu.link.cms.content.add"><![CDATA[Add content]]></item>
+		<item name="cms.acp.menu.link.cms.content.section.list"><![CDATA[List content sections]]></item>
+		<item name="cms.acp.menu.link.cms.stylesheet.list"><![CDATA[List stylesheets]]></item>
+		<item name="cms.acp.menu.link.cms.stylesheet.add"><![CDATA[Add stylesheet]]></item>
+		<item name="cms.acp.menu.link.cms.layout.list"><![CDATA[List layouts]]></item>
+		<item name="cms.acp.menu.link.cms.layout.add"><![CDATA[Add layout]]></item>
+		<item name="cms.acp.menu.link.cms.file.management"><![CDATA[Filemanagement]]></item>
+		<item name="cms.acp.menu.link.cms.news.category.add"><![CDATA[Add category]]></item>
+		<item name="cms.acp.menu.link.cms.news.category.list"><![CDATA[List categories]]></item>
+		<item name="cms.acp.menu.link.cms.style"><![CDATA[Displaymanagement]]></item>
+		<item name="cms.acp.menu.link.cms.content"><![CDATA[Pagemanagement]]></item>
+		<item name="cms.acp.menu.link.cms.news"><![CDATA[News]]></item>
+		<item name="cms.acp.menu.link.cms.module.add"><![CDATA[Add module]]></item>
+		<item name="cms.acp.menu.link.cms.module.list"><![CDATA[List modules]]></item>
+		<item name="cms.acp.menu.link.cms.dashboard"><![CDATA[Dashboard]]></item>
+		<item name="cms.acp.menu.link.cms.page.dashboard"><![CDATA[Dashboard]]></item>
+		<item name="cms.acp.menu.link.cms.page.statistics"><![CDATA[Statistics]]></item>
+		<item name="cms.acp.menu.link.cms.media"><![CDATA[Media]]></item>
+		<item name="cms.acp.menu.link.cms.news.image.list"><![CDATA[List news images]]></item>
+		<item name="cms.acp.menu.link.cms.news.image.add"><![CDATA[Add news image]]></item>
+	</category>
+
+	<category name="cms.acp.module">
+		<item name="cms.acp.module.list"><![CDATA[List modules]]></item>
+		<item name="cms.acp.module.add"><![CDATA[Add module]]></item>
+		<item name="cms.acp.module.edit"><![CDATA[Edit module]]></item>
+		<item name="cms.acp.module.general"><![CDATA[General]]></item>
+		<item name="cms.acp.module.php"><![CDATA[PHP-Source]]></item>
+		<item name="cms.acp.module.php.description"><![CDATA[You can use PHP-Syntax here. <strong>Danger</strong>: PHP-Errors might cause a non functionally site.]]></item>
+		<item name="cms.acp.module.tpl"><![CDATA[Template-Source]]></item>
+		<item name="cms.acp.module.tpl.description"><![CDATA[You can use Smarty-Syntax here (<a href="http://www.smarty.net/">Documentation</a>).]]></item>
+		<item name="cms.acp.module.title"><![CDATA[Title]]></item>
+		<item name="cms.acp.module.delete.sure"><![CDATA[Are you sure you want to delete this module?]]></item>
+	</category>
+
+	<category name="cms.acp.news">
 		<item name="cms.acp.news.image.data"><![CDATA[Data]]></item>
 		<item name="cms.acp.news.image.title"><![CDATA[Title]]></item>
 		<item name="cms.acp.news.image"><![CDATA[News image]]></item>
@@ -233,6 +180,77 @@
 		<item name="cms.acp.news.image"><![CDATA[Preview]]></item>
 	</category>
 
+	<category name="cms.acp.page">
+		<item name="cms.acp.page.list"><![CDATA[Pages]]></item>
+		<item name="cms.acp.page.add"><![CDATA[Add page]]></item>
+		<item name="cms.acp.page.edit"><![CDATA[Edit page]]></item>
+		<item name="cms.acp.page.title"><![CDATA[Pagetitle]]></item>
+		<item name="cms.acp.page.content.list"><![CDATA[List contents of '{$page->title|language}']]></item>
+		<item name="cms.acp.page.description"><![CDATA[Description]]></item>
+		<item name="cms.acp.page.setAsHome"><![CDATA[Set as startpage]]></item>
+		<item name="cms.acp.page.setAsHome.confirmMessage"><![CDATA[Do you want to set this page as your CMS Startpage? If there is a menu item for this page yet, it will be deleted.]]></item>
+		<item name="cms.acp.page.homePage"><![CDATA[Startpage]]></item>
+		<item name="cms.acp.page.general"><![CDATA[General]]></item>
+		<item name="cms.acp.page.general.parentID"><![CDATA[Parent page]]></item>
+		<item name="cms.acp.page.general.alias"><![CDATA[URL-Alias]]></item>
+		<item name="cms.acp.page.general.menuItem"><![CDATA[Add menu item]]></item>
+		<item name="cms.acp.page.general.menuItem.description"><![CDATA[]]></item>
+		<item name="cms.acp.page.alias.error.given"><![CDATA[Alias exists!]]></item>
+		<item name="cms.acp.page.alias.error.invalid"><![CDATA[Invalid Alias!]]></item>
+		<item name="cms.acp.page.general.alias.preview"><![CDATA[Link-Preview:]]></item>
+		<item name="cms.acp.page.general.alias.description"><![CDATA[The so called alias will be this page's link. It must not contain any other items than lowercase-letters, numbers and hyphens.]]></item>
+		<item name="cms.acp.page.general.description"><![CDATA[Description]]></item>
+		<item name="cms.acp.page.overview"><![CDATA[Overview]]></item>
+		<item name="cms.acp.page.meta"><![CDATA[Metainfomation]]></item>
+		<item name="cms.acp.page.meta.metaDescription"><![CDATA[Meta-Description]]></item>
+		<item name="cms.acp.page.metaDescription.description"><![CDATA[The meta element "description" is neccessary for a good CTR (Click-Through-Rate).]]></item>
+		<item name="cms.acp.page.meta.metaKeywords"><![CDATA[Meta-Keywords]]></item>
+		<item name="cms.acp.page.meta.robots"><![CDATA[Meta-Robots]]></item>
+		<item name="cms.acp.page.meta.robots.indexfollow"><![CDATA[index, follow (default)]]></item>
+		<item name="cms.acp.page.meta.robots.indexnofollow"><![CDATA[index, no follow]]></item>
+		<item name="cms.acp.page.meta.robots.noindexfollow"><![CDATA[no index, follow]]></item>
+		<item name="cms.acp.page.meta.robots.noindexnofollow"><![CDATA[no index, no follow]]></item>
+		<item name="cms.acp.page.settings"><![CDATA[Settings]]></item>
+		<item name="cms.acp.page.settings.showSidebar"><![CDATA[Show sidebar]]></item>
+		<item name="cms.acp.page.settings.sidebarOrientation"><![CDATA[Sidebarorientation]]></item>
+		<item name="cms.acp.page.settings.sidebarOrientation.right"><![CDATA[Right]]></item>
+		<item name="cms.acp.page.settings.sidebarOrientation.left"><![CDATA[Left]]></item>
+		<item name="cms.acp.page.content.add"><![CDATA[Add contents to'{$page->title|language}']]></item>
+		<item name="cms.acp.page.settings.isCommentable"><![CDATA[Allow comments]]></item>
+		<item name="cms.acp.page.settings.isCommentable.description"><![CDATA[]]></item>
+		<item name="cms.acp.page.settings.layoutID"><![CDATA[Choose layout]]></item>
+		<item name="cms.acp.page.menuItem.error.exists"><![CDATA[A Menuitem with this values already exists. For technical reasons you cannnot create a new one.]]></item>
+		<item name="cms.acp.page.settings.availableDuringOfflineMode"><![CDATA[Page is visible during offline mode]]></item>
+		<item name="cms.acp.page.visibility"><![CDATA[Visibility]]></item>
+		<item name="cms.acp.page.userPermissions"><![CDATA[Permissions]]></item>
+		<item name="cms.acp.page.delete.sure"><![CDATA[Are you sure you want to delete this page and all of its contents?]]></item>
+		<item name="cms.acp.page.position"><![CDATA[Position]]></item>
+		<item name="cms.acp.page.position.description"><![CDATA[]]></item>
+		<item name="cms.acp.page.position.invisible"><![CDATA[Invisible]]></item>
+		<item name="cms.acp.page.position.invisible.description"><![CDATA[]]></item>
+	</category>
+
+	<category name="cms.acp.stats">
+		<item name="cms.acp.stats"><![CDATA[Statistics]]></item>
+		<item name="cms.acp.stats.vistors"><![CDATA[Visitors]]></item>
+		<item name="cms.acp.stats.browsers"><![CDATA[Browsers]]></item>
+		<item name="cms.acp.stats.mostClicked"><![CDATA[Most visited pages]]></item>
+		<item name="cms.acp.stats.page"><![CDATA[Page]]></item>
+		<item name="cms.acp.stats.clicks"><![CDATA[Clicks]]></item>
+		<item name="cms.acp.stats.vistors"><![CDATA[Current visitors]]></item>
+	</category>
+
+	<category name="cms.acp.stylesheet">
+		<item name="cms.acp.stylesheet.list"><![CDATA[Stylesheets]]></item>
+		<item name="cms.acp.stylesheet.title"><![CDATA[Title]]></item>
+		<item name="cms.acp.stylesheet.general"><![CDATA[General]]></item>
+		<item name="cms.acp.stylesheet.add"><![CDATA[Add stylesheet]]></item>
+		<item name="cms.acp.stylesheet.edit"><![CDATA[Edit stylesheet]]></item>
+		<item name="cms.acp.stylesheet.less"><![CDATA[CSS & Less]]></item>
+		<item name="cms.acp.stylesheet.less.description"><![CDATA[]]></item>
+		<item name="cms.acp.stylesheet.delete.sure"><![CDATA[Are you sure you want to delete this stylesheet?]]></item>
+	</category>
+
 	<category name="cms.page">
 		<item name="cms.page.copyright"><![CDATA[<address class="copyright marginTop"><a href="http://codequake.de" {if EXTERNAL_LINK_TARGET_BLANK} target="_blank"{/if} title="">Software: <strong>Fireball CMS{if SHOW_VERSION_NUMBER} {@PACKAGE_VERSION}{/if}</strong>, developed by <strong>codeQuake</strong></a></address>]]></item>
 		<item name="cms.page.placeholder"><![CDATA[Add a startpage...]]></item>
@@ -240,21 +258,17 @@
 		<item name="cms.page.comments"><![CDATA[Comments]]></item>
 		<item name="cms.page.comment.notification.title"><![CDATA[New comment (Page)]]></item>
 		<item name="cms.page.comment.notification.message"><![CDATA[commented on „{$page->getTitle()|language}“.]]></item>
-		<item name="cms.page.comment.notification.mail">
-			<item name="cms.page.comments.noEntries"><![CDATA[No Entries.]]></item>
-      <![CDATA[{@$author->username} commented on "{@$page->getTitle()}":
-{link application='cms' controller='Page' object=$page encode=false forceFrontend=true}#comments{/link}]]>
-		</item>
+		<item name="cms.page.comment.notification.mail"><![CDATA[{@$author->username} commented on "{@$page->getTitle()}":
+{link application='cms' controller='Page' object=$page encode=false forceFrontend=true}#comments{/link}]]></item>
+		<item name="cms.page.comments.noEntries"><![CDATA[No Entries.]]></item>
 		<item name="cms.page.commentResponse.notification.title"><![CDATA[New response (Page)]]></item>
 		<item name="cms.page.commentResponse.notification.message"><![CDATA[left a response to your comment on „{$page->getTitle()|language}“.]]></item>
-		<item name="cms.page.commentResponse.notification.mail">
-      <![CDATA[{@$author->username} left a response to your comment on "{@$page->getTitle|language}":
+		<item name="cms.page.commentResponse.notification.mail"><![CDATA[{@$author->username} left a response to your comment on "{@$page->getTitle|language}":
 {link application='cms' controller='Page' object=$page encode=false forceFrontend=true}#comments{/link}]]>
 		</item>
 		<item name="cms.page.commentResponseOwner.notification.title"><![CDATA[New Response (Page)]]></item>
 		<item name="cms.page.commentResponseOwner.notification.message"><![CDATA[left a response to „{$commentAuthor->username}“'s comment on „{$page->getTitle()|language}“.]]></item>
-		<item name="cms.page.commentResponseOwner.notification.mail">
-      <![CDATA[{@$author->username} left a response to „{$commentAuthor->username}“'s comment on „{$page->getTitle()|language}“:
+		<item name="cms.page.commentResponseOwner.notification.mail"><![CDATA[{@$author->username} left a response to „{$commentAuthor->username}“'s comment on „{$page->getTitle()|language}“:
 {link application='cms' controller='Page' object=$page encode=false forceFrontend=true}#comments{/link}]]>
 		</item>
 	</category>
@@ -286,20 +300,17 @@
 		<item name="cms.news.delete.sure"><![CDATA[Are you sure you want to delete this news?]]></item>
 		<item name="cms.news.comment.notification.title"><![CDATA[New comment (news)]]></item>
 		<item name="cms.news.comment.notification.message"><![CDATA[Commented on your news “{$news->subject}”.]]></item>
-		<item name="cms.news.comment.notification.mail">
-      <![CDATA[{@$author->username} commented on your news "{@$news->subject}":
+		<item name="cms.news.comment.notification.mail"><![CDATA[{@$author->username} commented on your news "{@$news->subject}":
 {link application='cms' controller='News' object=$news encode=false forceFrontend=true}#comments{/link}]]>
 		</item>
 		<item name="cms.news.commentResponse.notification.title"><![CDATA[New reply (news)]]></item>
 		<item name="cms.news.commentResponse.notification.message"><![CDATA[Replied to your comment on the news “{$news->subject}”.]]></item>
-		<item name="cms.news.commentResponse.notification.mail">
-      <![CDATA[{@$author->username} replied to your comment on the news "{@$news->subject}":
+		<item name="cms.news.commentResponse.notification.mail"><![CDATA[{@$author->username} replied to your comment on the news "{@$news->subject}":
 {link application='cms' controller='News' object=$news encode=false forceFrontend=true}#comments{/link}]]>
 		</item>
 		<item name="cms.news.commentResponseOwner.notification.title"><![CDATA[New reply (news)]]></item>
 		<item name="cms.news.commentResponseOwner.notification.message"><![CDATA[Replied to a comment by “{$commentAuthor->username}” on the news “{$news->subject}”.]]></item>
-		<item name="cms.news.commentResponseOwner.notification.mail">
-      <![CDATA[{@$author->username} replied to a comment by "{@$commentAuthor->username}" on the news "{@$news->subject}":
+		<item name="cms.news.commentResponseOwner.notification.mail"><![CDATA[{@$author->username} replied to a comment by "{@$commentAuthor->username}" on the news "{@$news->subject}":
 {link application='cms' controller='News' object=$news encode=false forceFrontend=true}#comments{/link}]]>
 		</item>
 		<item name="cms.news.comments.noEntries"><![CDATA[No Comments available]]></item>
@@ -377,8 +388,7 @@
 		<item name="wcf.acp.group.option.admin.cms.content.canUploadAttachment"><![CDATA[Can attach files]]></item>
 		<item name="wcf.acp.group.option.admin.cms.content.attachmentMaxSize"><![CDATA[Maximum filesize]]></item>
 		<item name="wcf.acp.group.option.admin.cms.content.maxAttachmentCount"><![CDATA[Maximum number of attachments per content section]]></item>
-		<item
-			name="wcf.acp.group.option.admin.cms.content.allowedAttachmentExtensions"><![CDATA[Allowed file extensions]]></item>
+		<item name="wcf.acp.group.option.admin.cms.content.allowedAttachmentExtensions"><![CDATA[Allowed file extensions]]></item>
 		<item name="wcf.acp.group.option.user.cms.news.canViewDelayedNews"><![CDATA[Can see unpublished news]]></item>
 
 	</category>
@@ -393,8 +403,7 @@
 		<item name="wcf.acl.option.de.codequake.cms.category.news.canAddNews"><![CDATA[Can add news]]></item>
 		<item name="wcf.acl.option.de.codequake.cms.category.news.canModerateNews"><![CDATA[Nachrichten Moderationsrecht]]></item>
 		<item name="wcf.acl.option.de.codequake.cms.category.news.canModerateNews"><![CDATA[Can see unpublished news]]></item>
-		<item
-			name="wcf.acl.option.de.codequake.cms.category.news.canViewDelayedNews"><![CDATA[Can view delayed news]]></item>
+		<item name="wcf.acl.option.de.codequake.cms.category.news.canViewDelayedNews"><![CDATA[Can view delayed news]]></item>
 	</category>
 
 	<category name="wcf.acp.option">
@@ -435,21 +444,15 @@
 	</category>
 
 	<category name="wcf.user.recentActivity">
-		<item
-			name="wcf.user.recentActivity.de.codequake.cms.news.recentActivityEvent"><![CDATA[News]]></item>
-		<item
-			name="wcf.user.recentActivity.de.codequake.cms.page.comment.recentActivityEvent"><![CDATA[Comment (Page)]]></item>
-		<item
-			name="wcf.user.recentActivity.de.codequake.cms.page.comment.response.recentActivityEvent"><![CDATA[Response (Page)]]></item>
-		<item
-			name="wcf.user.recentActivity.de.codequake.cms.news.comment.recentActivityEvent"><![CDATA[Comment (News)]]></item>
-		<item
-			name="wcf.user.recentActivity.de.codequake.cms.news.comment.response.recentActivityEvent"><![CDATA[Response (News)]]></item>
+		<item name="wcf.user.recentActivity.de.codequake.cms.news.recentActivityEvent"><![CDATA[News]]></item>
+		<item name="wcf.user.recentActivity.de.codequake.cms.page.comment.recentActivityEvent"><![CDATA[Comment (Page)]]></item>
+		<item name="wcf.user.recentActivity.de.codequake.cms.page.comment.response.recentActivityEvent"><![CDATA[Response (Page)]]></item>
+		<item name="wcf.user.recentActivity.de.codequake.cms.news.comment.recentActivityEvent"><![CDATA[Comment (News)]]></item>
+		<item name="wcf.user.recentActivity.de.codequake.cms.news.comment.response.recentActivityEvent"><![CDATA[Response (News)]]></item>
 	</category>
 
 	<category name="wcf.user.activityPoint">
-		<item
-			name="wcf.user.activityPoint.objectType.de.codequake.cms.activityPointEvent.news"><![CDATA[News]]></item>
+		<item name="wcf.user.activityPoint.objectType.de.codequake.cms.activityPointEvent.news"><![CDATA[News]]></item>
 	</category>
 
 	<category name="wcf.tagging">
@@ -466,17 +469,15 @@
 		<item name="wcf.search.type.de.codequake.cms.news"><![CDATA[News]]></item>
 		<item name="wcf.search.object.de.codequake.cms.news"><![CDATA[News]]></item>
 	</category>
+
 	<category name="wcf.user.notification">
 		<item name="wcf.user.notification.de.codequake.cms"><![CDATA[CMS]]></item>
-		<item
-			name="wcf.user.notification.de.codequake.cms.news.comment.notification.comment"><![CDATA[New comment to one of your news]]></item>
-		<item
-			name="wcf.user.notification.de.codequake.cms.news.comment.response.notification.commentResponse"><![CDATA[New response to one of your comments to a news]]></item>
-		<item
-			name="wcf.user.notification.de.codequake.cms.news.comment.response.notification.commentResponseOwner"><![CDATA[New response to a comment to one of your news]]></item>
-		<item
-			name="wcf.user.notification.de.codequake.cms.page.comment.response.notification.commentResponse"><![CDATA[New response to a comment on a page]]></item>
+		<item name="wcf.user.notification.de.codequake.cms.news.comment.notification.comment"><![CDATA[New comment to one of your news]]></item>
+		<item name="wcf.user.notification.de.codequake.cms.news.comment.response.notification.commentResponse"><![CDATA[New response to one of your comments to a news]]></item>
+		<item name="wcf.user.notification.de.codequake.cms.news.comment.response.notification.commentResponseOwner"><![CDATA[New response to a comment to one of your news]]></item>
+		<item name="wcf.user.notification.de.codequake.cms.page.comment.response.notification.commentResponse"><![CDATA[New response to a comment on a page]]></item>
 	</category>
+
 	<category name="wcf.acp.dataImport">
 		<item name="wcf.acp.dataImport.data.de.codequake.cms.news"><![CDATA[News]]></item>
 		<item name="wcf.acp.dataImport.data.de.codequake.cms.category.news"><![CDATA[News categories]]></item>


### PR DESCRIPTION
This pull request applies further improvements to the page add form:
![unknown](https://cloud.githubusercontent.com/assets/2105496/2766974/eeac5450-ca33-11e3-998c-bf8dd1d1b48c.png)

Furthermore, I've reordered the language file. The acp related language variables, prior all grouped in `cms.acp`, now are grouped more precisely by their general application area (e.g. `cms.acp.page` or `cms.acp.content`)
