### PR TITLE
Improve alias system

### DIFF
--- a/acptemplates/pageAdd.tpl
+++ b/acptemplates/pageAdd.tpl
@@ -5,7 +5,7 @@
 	//<![CDATA[
 	$(function() {
 		WCF.Language.addObject({
-			'cms.acp.page.general.alias.preview': '{lang}cms.acp.page.general.alias.preview{/lang}',
+			'cms.acp.page.alias.preview': '{lang}cms.acp.page.alias.preview{/lang}',
 		});
 
 		WCF.TabMenu.init();
@@ -77,11 +77,9 @@
 				</dl>
 
 				<dl{if $errorField == 'alias'} class="formError"{/if}>
-					<dt><label for="alias">{lang}cms.acp.page.general.alias{/lang}</label></dt>
+					<dt><label for="alias">{lang}cms.acp.page.alias{/lang}</label></dt>
 					<dd>
 						<input type="text" id="alias" name="alias" value="{$alias}" class="long" required="required" />
-						<small>{lang}cms.acp.page.general.alias.description{/lang}</small>
-						<small id="aliasPreview"></small>
 						{if $errorField == 'alias'}
 							<small class="innerError">
 								{if $errorType == 'empty'}
@@ -91,6 +89,8 @@
 								{/if}
 							</small>
 						{/if}
+						<small>{lang}cms.acp.page.alias.description{/lang}</small>
+						<small id="aliasPreview"></small>
 					</dd>
 				</dl>
 

--- a/files/acp/js/CMS.ACP.js
+++ b/files/acp/js/CMS.ACP.js
@@ -6,7 +6,6 @@ CMS.ACP.Page = {};
 CMS.ACP.Page.AddForm = Class.extend({
 	init: function () {
 		$('#alias, #parentID').change($.proxy(this._buildAliasPreview, this));
-		$('#title').change($.proxy(this._buildAlias, this));
 		this._buildAliasPreview();
 	},
 
@@ -19,36 +18,13 @@ CMS.ACP.Page.AddForm = Class.extend({
 				$aliasPreview += $aliasParent + '/';
 			}
 			$aliasPreview += $alias + '/';
-			$('#aliasPreview').html(WCF.Language.get('cms.acp.page.general.alias.preview') + ' ' +  $aliasPreview).show();
+			$('#aliasPreview').html(WCF.Language.get('cms.acp.page.alias.preview') + ' ' +  $aliasPreview).show();
 		}
 		else { $('#aliasPreview').hide(); }
-	},
-
-	_buildAlias: function(){
-		var $alias = $('#alias').val();
-		//prevent alias from beeing overwritten
-		if($alias == ''){
-			var $title = $('#title').val();
-			var $minus = [" ", "\\", "/", ":", ";", ".", "_", ","];
-			$minus.forEach(function(entry){
-				$title = $title.replace(entry, "-");
-			});
-
-			var $empty = ["{", "}", "[", "]", "&", "%", "$", "§", "\"", "!", "*", "'", "+", "#", "@", "<", ">", "|", "µ", "?", ")", "("];
-			$empty.forEach(function(entry){
-				$title = $title.replace(entry, "");
-			});
-
-			$title = $title.toLowerCase();
-
-			$('#alias').val($title);
-			this._buildAliasPreview();
-		}
 	}
 });
 
 CMS.ACP.Page.Menu = Class.extend({
-
 	init: function () {
 		$('#menuItemParameters').change($.proxy(this._showNotice, this));
 		$('#menuItemController').change($.proxy(this._showNotice, this));
@@ -65,7 +41,6 @@ CMS.ACP.Page.Menu = Class.extend({
 }),
 
 CMS.ACP.Page.AddContent = Class.extend({
-
 	_buttonSelector: '.jsContentAddButton',
 	_proxy: null,
 	_cache: {},
@@ -116,9 +91,7 @@ CMS.ACP.Page.AddContent = Class.extend({
 	}
 });
 
-
 CMS.ACP.Page.SetAsHome = Class.extend({
-
 	_buttonSelector: '.jsSetAsHome',
 	_proxy: null,
 	_didInit: false,
@@ -157,13 +130,11 @@ CMS.ACP.Page.SetAsHome = Class.extend({
 			window.location = location;
 		});
 	}
-
 });
 
 CMS.ACP.File = {};
 
 CMS.ACP.File.Upload = WCF.Upload.extend({
-
 	_folderID: 0,
 
 	//calls parent init with params
@@ -184,6 +155,7 @@ CMS.ACP.File.Upload = WCF.Upload.extend({
 	_getParameters: function() {
 		return {'folderID': this._folderID};
 	},
+
 	_success: function(uploadID, data) {
 		var $li = this._fileListSelector.find('li');
 		//remove progressbar
@@ -388,7 +360,6 @@ CMS.ACP.Content.Image.Gallery = Class.extend({
 CMS.ACP.Image = {};
 
 CMS.ACP.Image.Ratio = Class.extend({
-
 	_ratio: 1,
 
 	init: function(width, height) {
@@ -455,67 +426,66 @@ CMS.ACP.Page.Revisions = Class.extend({
 	}
 });
 
-
 CMS.ACP.Page.Revisions.Restore = Class.extend({
 	_proxy: null,
 	_didInit:false,
 
 	init: function () {
-			if (this._didInit) {
-				return;
-			}
-			this._proxy = new WCF.Action.Proxy({
-				success: $.proxy(this._success, this)
-			});
-
-			this._buttons = $('.jsRestoreRevisionButton');
-			this._buttons.click($.proxy(this._click, this));
-
-			this._didInit = true;
-		},
-
-		_click: function (event) {
-			event.preventDefault();
-			var $target = $(event.currentTarget);
-
-			if ($target.data('confirmMessage')) {
-				WCF.System.Confirmation.show($target.data('confirmMessage'), $.proxy(this._execute, this), { target: $target });
-			}
-			else {
-				WCF.LoadingOverlayHandler.updateIcon($target);
-				this._sendRequest($target);
-			}
-		},
-
-		_sendRequest: function (object) {
-			$pageID = $(object).data('pageID');
-			$versionID = $(object).data('objectID');
-			this._proxy.setOption('data', {
-				actionName: 'restoreRevision',
-				className: 'cms\\data\\page\\PageAction',
-				objectIDs: [ $pageID ],
-				parameters: {
-					'restoreObjectID': $versionID
-				}
-			});
-			this._proxy.sendRequest();
-		},
-
-		_execute: function (action, parameters) {
-			if (action === 'cancel') {
-				return;
-			}
-
-			WCF.LoadingOverlayHandler.updateIcon(parameters.target);
-			this._sendRequest(parameters.target);
-		},
-
-		_success: function (data, textStatus, jqXHR) {
-			var $notification = new WCF.System.Notification(WCF.Language.get('wcf.global.success'));
-			$notification.show(function() {
-				window.location = location;
-			});
+		if (this._didInit) {
+			return;
 		}
+		this._proxy = new WCF.Action.Proxy({
+			success: $.proxy(this._success, this)
+		});
+
+		this._buttons = $('.jsRestoreRevisionButton');
+		this._buttons.click($.proxy(this._click, this));
+
+		this._didInit = true;
+	},
+
+	_click: function (event) {
+		event.preventDefault();
+		var $target = $(event.currentTarget);
+
+		if ($target.data('confirmMessage')) {
+			WCF.System.Confirmation.show($target.data('confirmMessage'), $.proxy(this._execute, this), { target: $target });
+		}
+		else {
+			WCF.LoadingOverlayHandler.updateIcon($target);
+			this._sendRequest($target);
+		}
+	},
+
+	_sendRequest: function (object) {
+		$pageID = $(object).data('pageID');
+		$versionID = $(object).data('objectID');
+		this._proxy.setOption('data', {
+			actionName: 'restoreRevision',
+			className: 'cms\\data\\page\\PageAction',
+			objectIDs: [ $pageID ],
+			parameters: {
+				'restoreObjectID': $versionID
+			}
+		});
+		this._proxy.sendRequest();
+	},
+
+	_execute: function (action, parameters) {
+		if (action === 'cancel') {
+			return;
+		}
+
+		WCF.LoadingOverlayHandler.updateIcon(parameters.target);
+		this._sendRequest(parameters.target);
+	},
+
+	_success: function (data, textStatus, jqXHR) {
+		var $notification = new WCF.System.Notification(WCF.Language.get('wcf.global.success'));
+		$notification.show(function() {
+			window.location = location;
+		});
+	}
 });
 
 CMS.ACP.Content.Revisions = Class.extend({
@@ -563,71 +533,69 @@ CMS.ACP.Content.Revisions = Class.extend({
 	}
 });
 
-
 CMS.ACP.Content.Revisions.Restore = Class.extend({
 	_proxy: null,
 	_didInit:false,
 
 	init: function () {
-			if (this._didInit) {
-				return;
-			}
-			this._proxy = new WCF.Action.Proxy({
-				success: $.proxy(this._success, this)
-			});
-
-			this._buttons = $('.jsRestoreRevisionButton');
-			this._buttons.click($.proxy(this._click, this));
-
-			this._didInit = true;
-		},
-
-		_click: function (event) {
-			event.preventDefault();
-			var $target = $(event.currentTarget);
-
-			if ($target.data('confirmMessage')) {
-				WCF.System.Confirmation.show($target.data('confirmMessage'), $.proxy(this._execute, this), { target: $target });
-			}
-			else {
-				WCF.LoadingOverlayHandler.updateIcon($target);
-				this._sendRequest($target);
-			}
-		},
-
-		_sendRequest: function (object) {
-			$contentID = $(object).data('contentID');
-			$versionID = $(object).data('objectID');
-			this._proxy.setOption('data', {
-				actionName: 'restoreRevision',
-				className: 'cms\\data\\content\\ContentAction',
-				objectIDs: [ $contentID ],
-				parameters: {
-					'restoreObjectID': $versionID
-				}
-			});
-			this._proxy.sendRequest();
-		},
-
-		_execute: function (action, parameters) {
-			if (action === 'cancel') {
-				return;
-			}
-
-			WCF.LoadingOverlayHandler.updateIcon(parameters.target);
-			this._sendRequest(parameters.target);
-		},
-
-		_success: function (data, textStatus, jqXHR) {
-			var $notification = new WCF.System.Notification(WCF.Language.get('wcf.global.success'));
-			$notification.show(function() {
-				window.location = location;
-			});
+		if (this._didInit) {
+			return;
 		}
+		this._proxy = new WCF.Action.Proxy({
+			success: $.proxy(this._success, this)
+		});
+
+		this._buttons = $('.jsRestoreRevisionButton');
+		this._buttons.click($.proxy(this._click, this));
+
+		this._didInit = true;
+	},
+
+	_click: function (event) {
+		event.preventDefault();
+		var $target = $(event.currentTarget);
+
+		if ($target.data('confirmMessage')) {
+			WCF.System.Confirmation.show($target.data('confirmMessage'), $.proxy(this._execute, this), { target: $target });
+		}
+		else {
+			WCF.LoadingOverlayHandler.updateIcon($target);
+			this._sendRequest($target);
+		}
+	},
+
+	_sendRequest: function (object) {
+		$contentID = $(object).data('contentID');
+		$versionID = $(object).data('objectID');
+		this._proxy.setOption('data', {
+			actionName: 'restoreRevision',
+			className: 'cms\\data\\content\\ContentAction',
+			objectIDs: [ $contentID ],
+			parameters: {
+				'restoreObjectID': $versionID
+			}
+		});
+		this._proxy.sendRequest();
+	},
+
+	_execute: function (action, parameters) {
+		if (action === 'cancel') {
+			return;
+		}
+
+		WCF.LoadingOverlayHandler.updateIcon(parameters.target);
+		this._sendRequest(parameters.target);
+	},
+
+	_success: function (data, textStatus, jqXHR) {
+		var $notification = new WCF.System.Notification(WCF.Language.get('wcf.global.success'));
+		$notification.show(function() {
+			window.location = location;
+		});
+	}
 });
 
 CMS.ACP.Copy = Class.extend({
-
 	_buttonSelector: '.jsCopyButton',
 	_objectAction: 'cms\\data\\page\\PageAction',
 	_proxy: null,
@@ -668,5 +636,4 @@ CMS.ACP.Copy = Class.extend({
 			location.reload();
 		});
 	}
-
 });

--- a/files/lib/acp/form/PageEditForm.class.php
+++ b/files/lib/acp/form/PageEditForm.class.php
@@ -82,11 +82,11 @@ class PageEditForm extends PageAddForm {
 		if (empty($this->alias)) {
 			throw new UserInputException('alias');
 		}
-		if (! PageUtil::isValidAlias($this->alias)) {
-			throw new UserInputException('alias', 'invalid');
+		if (!PageUtil::isValidAlias($this->alias)) {
+			throw new UserInputException('alias', 'notValid');
 		}
-		if (! PageUtil::isAvailableAlias($this->alias, ($this->parentID) ?  : null, $this->pageID)) {
-			throw new UserInputException('alias', 'given');
+		if (!PageUtil::isAvailableAlias($this->alias, ($this->parentID) ?: null, $this->pageID)) {
+			throw new UserInputException('alias', 'notUnique');
 		}
 	}
 

--- a/files/lib/util/PageUtil.class.php
+++ b/files/lib/util/PageUtil.class.php
@@ -12,8 +12,47 @@ use cms\data\page\PageCache;
  * @package	de.codequake.cms
  */
 final class PageUtil {
+	/**
+	 * maximum length of an alias
+	 * @var	integer
+	 */
+	const ALIAS_MAXLENGTH = 25;
 
+	/**
+	 * minimum length of an alias
+	 * @var	integer
+	 */
+	const ALIAS_MINLENGTH = 3;
+
+	/**
+	 * general pattern for an alias
+	 * @var	string
+	 */
 	const ALIAS_PATTERN = '[a-z0-9]+(?:\-{1}[a-z0-9]+)*';
+
+	/**
+	 * pattern of a stack of aliases, devided by slashes
+	 * @var	string
+	 */
+	const ALIAS_PATTERN_STACK = '[a-z0-9]+(?:\-{1}[a-z0-9]+)*(?:\/[a-z0-9]+(?:\-{1}[a-z0-9]+)*)*';
+
+	/**
+	 * Builds an alias based upon the given page title automatically.
+	 * Caution: Though the generated alias is valid, you have to check
+	 * whether the alias is available at the used position.
+	 * 
+	 * @param	string		$title
+	 * @return	string
+	 */
+	public static function buildAlias($title) {
+		// remove illegal characters
+		$title = trim(preg_replace('~[^a-z0-9\-]+~', '', mb_strtolower($title)), '-');
+
+		// trim to maxlength
+		$title = mb_substr($title, 0, self::ALIAS_MAXLENGTH);
+
+		return $title;
+	}
 
 	/**
 	 * Returns true if the given alias is available at the given position.
@@ -29,7 +68,7 @@ final class PageUtil {
 	public static function isAvailableAlias($alias, $parentPageID, $excludedPageID = null) {
 		$childIDs = PageCache::getInstance()->getChildIDs($parentPageID);
 		
-		if (! empty($childIDs)) {
+		if (!empty($childIDs)) {
 			foreach ($childIDs as $childID) {
 				if ($childID == $excludedPageID) continue;
 				
@@ -50,7 +89,12 @@ final class PageUtil {
 	 * @return	boolean
 	 */
 	public static function isValidAlias($alias) {
-		return preg_match('~^' . self::ALIAS_PATTERN . '$~', $alias);
+		// check for min and maxlength
+		if (mb_strlen($alias) < self::ALIAS_MINLENGTH || mb_strlen($alias) > self::ALIAS_MAXLENGTH) {
+			return false;
+		}
+
+		return (preg_match('~^' . self::ALIAS_PATTERN . '$~', $alias) == 1);
 	}
 
 	private function __construct() { /* nothing */ }

--- a/files_wcf/lib/system/event/listener/CMSRouteHandlerListener.class.php
+++ b/files_wcf/lib/system/event/listener/CMSRouteHandlerListener.class.php
@@ -8,20 +8,25 @@ use wcf\system\event\IEventListener;
 use wcf\system\request\RouteHandler;
 
 /**
+ * Registers cms route. Listener has to be placed within wcf namespace because
+ * application wouldn't be uninstallable otherwise.
+ * 
  * @author	Jens Krumsieck
  * @copyright	2014 codeQuake
  * @license	GNU Lesser General Public License <http://www.gnu.org/licenses/lgpl-3.0.txt>
  * @package	de.codequake.cms
  */
 class CMSRouteHandlerListener implements IEventListener {
-
+	/**
+	 * @see	\wcf\system\event\IEventListener::execute()
+	 */
 	public function execute($eventObj, $className, $eventName) {
 		// thx to SoftCreatR http://www.woltlab.com/forum/index.php/Thread/224017-Request-Handler/?postID=1332856#post1332856
 		$application = ApplicationHandler::getInstance()->getActiveApplication();
 		if (PACKAGE_ID != 1 && $application != null) {
 			$route = new Route('cmsPageRoute');
 			$route->setSchema('/{alias}/', 'Page');
-			$route->setParameterOption('alias', null, '[a-z0-9]+(?:\-{1}[a-z0-9]+)*(?:\/[a-z0-9]+(?:\-{1}[a-z0-9]+)*)*');
+			$route->setParameterOption('alias', null, PageUtil::ALIAS_PATTERN_STACK);
 			$eventObj->addRoute($route);
 		}
 	}

--- a/language/de.xml
+++ b/language/de.xml
@@ -27,13 +27,13 @@
 		<item name="cms.acp.content.css.cssID"><![CDATA[CSS-ID]]></item>
 		<item name="cms.acp.content.css.cssClasses"><![CDATA[CSS-Klassen]]></item>
 		<item name="cms.acp.content.css.cssClasses.description"><![CDATA[CSS Klassen sind wichtig für das spätere Aussehen der Inhalte, es empfehlen sich Einträge wie "container containerPadding". Für einen Abstand zum oberen Element nutzen sie zusätzlich "marginTop". <br/>
-																		<strong>Beispiele:</strong>
-																		<ul>
-																		<li><pre>container</pre> - Legt einen Rahmen um das Element</li>
-																		<li><pre>containerPadding</pre> - Zusammen mit container wird der Inhalt mit einem Abstand zum Rahmen versehen</li>
-																		<li><pre>marginTop</pre> - Weist dem Element einen Abstand nach oben zu</li>
-																		<li><pre>center</pre> - Zentriert den Inhalt des Elements</li>
-																		</ul>]]></item>
+<strong>Beispiele:</strong>
+<ul>
+	<li><pre>container</pre> - Legt einen Rahmen um das Element</li>
+	<li><pre>containerPadding</pre> - Zusammen mit container wird der Inhalt mit einem Abstand zum Rahmen versehen</li>
+	<li><pre>marginTop</pre> - Weist dem Element einen Abstand nach oben zu</li>
+	<li><pre>center</pre> - Zentriert den Inhalt des Elements</li>
+</ul>]]></item>
 		<item name="cms.acp.content.title"><![CDATA[Titel]]></item>
 		<item name="cms.acp.content.edit"><![CDATA[Inhalt bearbeiten]]></item>
 		<item name="cms.acp.content.position"><![CDATA[Position]]></item>
@@ -50,91 +50,60 @@
 		<item name="cms.acp.content.type.de.codequake.cms.content.type.text.text"><![CDATA[Text]]></item>
 		<item name="cms.acp.content.type.de.codequake.cms.content.type.link"><![CDATA[Hyperlink/Button]]></item>
 		<item name="cms.acp.content.type.de.codequake.cms.content.type.link.type"><![CDATA[Vorlage]]></item>
-		<item
-			name="cms.acp.content.type.de.codequake.cms.content.type.link.type.link"><![CDATA[Hyperlink]]></item>
-		<item
-			name="cms.acp.content.type.de.codequake.cms.content.type.link.type.button"><![CDATA[Button]]></item>
-		<item
-			name="cms.acp.content.type.de.codequake.cms.content.type.link.type.smallbutton"><![CDATA[Kleiner Button]]></item>
+		<item name="cms.acp.content.type.de.codequake.cms.content.type.link.type.link"><![CDATA[Hyperlink]]></item>
+		<item name="cms.acp.content.type.de.codequake.cms.content.type.link.type.button"><![CDATA[Button]]></item>
+		<item name="cms.acp.content.type.de.codequake.cms.content.type.link.type.smallbutton"><![CDATA[Kleiner Button]]></item>
 		<item name="cms.acp.content.type.de.codequake.cms.content.type.link.text"><![CDATA[Text]]></item>
-		<item
-			name="cms.acp.content.type.de.codequake.cms.content.type.link.hyperlink"><![CDATA[Hyperlink]]></item>
+		<item name="cms.acp.content.type.de.codequake.cms.content.type.link.hyperlink"><![CDATA[Hyperlink]]></item>
 		<item name="cms.acp.content.type.de.codequake.cms.content.type.tabmenu"><![CDATA[Tabmenu]]></item>
-		<item
-			name="cms.acp.content.type.de.codequake.cms.content.type.tabmenu.description"><![CDATA[Alle untergeordneten Inhalte werden als Tabs des Tabmenüs behandelt. Der Titel eines untergeordneten Inhaltes wird als Titel des Tab-Buttons verwendet. Sollte für einen untergeordneten Inhalt keine CSS-ID für den Anker angegeben werden, so wird eine CSS-ID generiert.]]></item>
+		<item name="cms.acp.content.type.de.codequake.cms.content.type.tabmenu.description"><![CDATA[Alle untergeordneten Inhalte werden als Tabs des Tabmenüs behandelt. Der Titel eines untergeordneten Inhaltes wird als Titel des Tab-Buttons verwendet. Sollte für einen untergeordneten Inhalt keine CSS-ID für den Anker angegeben werden, so wird eine CSS-ID generiert.]]></item>
 		<item name="cms.acp.content.type.de.codequake.cms.content.type.dashboard"><![CDATA[Dashboardbox]]></item>
-		<item
-			name="cms.acp.content.type.de.codequake.cms.content.type.dashboard.box"><![CDATA[Box auswählen]]></item>
+		<item name="cms.acp.content.type.de.codequake.cms.content.type.dashboard.box"><![CDATA[Box auswählen]]></item>
 		<item name="cms.acp.content.type.de.codequake.cms.content.type.headline"><![CDATA[Überschrift]]></item>
-		<item
-			name="cms.acp.content.type.de.codequake.cms.content.type.headline.type"><![CDATA[Formatvorlage]]></item>
-		<item
-			name="cms.acp.content.type.de.codequake.cms.content.type.headline.type.h1"><![CDATA[Überschrift 1]]></item>
-		<item
-			name="cms.acp.content.type.de.codequake.cms.content.type.headline.type.h2"><![CDATA[Überschrift 2]]></item>
-		<item
-			name="cms.acp.content.type.de.codequake.cms.content.type.headline.type.h3"><![CDATA[Überschrift 3]]></item>
-		<item
-			name="cms.acp.content.type.de.codequake.cms.content.type.headline.type.h4"><![CDATA[Überschrift 4]]></item>
-		<item
-			name="cms.acp.content.type.de.codequake.cms.content.type.headline.type.h5"><![CDATA[Überschrift 5]]></item>
-		<item
-			name="cms.acp.content.type.de.codequake.cms.content.type.headline.text"><![CDATA[Überschrift]]></item>
-		<item
-			name="cms.acp.content.type.de.codequake.cms.content.type.headline.hyperlink"><![CDATA[Hyperlink]]></item>
+		<item name="cms.acp.content.type.de.codequake.cms.content.type.headline.type"><![CDATA[Formatvorlage]]></item>
+		<item name="cms.acp.content.type.de.codequake.cms.content.type.headline.type.h1"><![CDATA[Überschrift 1]]></item>
+		<item name="cms.acp.content.type.de.codequake.cms.content.type.headline.type.h2"><![CDATA[Überschrift 2]]></item>
+		<item name="cms.acp.content.type.de.codequake.cms.content.type.headline.type.h3"><![CDATA[Überschrift 3]]></item>
+		<item name="cms.acp.content.type.de.codequake.cms.content.type.headline.type.h4"><![CDATA[Überschrift 4]]></item>
+		<item name="cms.acp.content.type.de.codequake.cms.content.type.headline.type.h5"><![CDATA[Überschrift 5]]></item>
+		<item name="cms.acp.content.type.de.codequake.cms.content.type.headline.text"><![CDATA[Überschrift]]></item>
+		<item name="cms.acp.content.type.de.codequake.cms.content.type.headline.hyperlink"><![CDATA[Hyperlink]]></item>
 		<item name="cms.acp.content.type.de.codequake.cms.content.type.group"><![CDATA[Gruppierung]]></item>
-		<item
-			name="cms.acp.content.type.de.codequake.cms.content.type.group.description"><![CDATA[Dieser Inhaltstyp gruppiert automatisch alle untergeordneten Inhalte.]]></item>
+		<item name="cms.acp.content.type.de.codequake.cms.content.type.group.description"><![CDATA[Dieser Inhaltstyp gruppiert automatisch alle untergeordneten Inhalte.]]></item>
 		<item name="cms.acp.content.type.de.codequake.cms.content.type.twocolumns"><![CDATA[Zweispaltig]]></item>
-		<item
-			name="cms.acp.content.type.de.codequake.cms.content.type.twocolumns.width"><![CDATA[Breite der Spalten]]></item>
-		<item
-			name="cms.acp.content.type.de.codequake.cms.content.type.threecolumns"><![CDATA[Dreispaltig]]></item>
-		<item
-			name="cms.acp.content.type.de.codequake.cms.content.type.threecolumns.width"><![CDATA[Breite der Spalten]]></item>
+		<item name="cms.acp.content.type.de.codequake.cms.content.type.twocolumns.width"><![CDATA[Breite der Spalten]]></item>
+		<item name="cms.acp.content.type.de.codequake.cms.content.type.threecolumns"><![CDATA[Dreispaltig]]></item>
+		<item name="cms.acp.content.type.de.codequake.cms.content.type.threecolumns.width"><![CDATA[Breite der Spalten]]></item>
 		<item name="cms.acp.content.type.de.codequake.cms.content.type.fourcolumns"><![CDATA[Vierspaltig]]></item>
-		<item
-			name="cms.acp.content.type.de.codequake.cms.content.type.fourcolumns.width"><![CDATA[Breite der Spalten]]></item>
+		<item name="cms.acp.content.type.de.codequake.cms.content.type.fourcolumns.width"><![CDATA[Breite der Spalten]]></item>
 		<item name="cms.acp.content.type.de.codequake.cms.content.type.template"><![CDATA[Template (Smarty)]]></item>
-		<item
-			name="cms.acp.content.type.de.codequake.cms.content.type.template.text"><![CDATA[Template-Quelltext]]></item>
-		<item
-			name="cms.acp.content.type.de.codequake.cms.content.type.template.text.description"><![CDATA[Hier können Sie Template-Quelltext verwenden (<a href="http://www.smarty.net/">Dokumentation</a>).]]></item>
+		<item name="cms.acp.content.type.de.codequake.cms.content.type.template.text"><![CDATA[Template-Quelltext]]></item>
+		<item name="cms.acp.content.type.de.codequake.cms.content.type.template.text.description"><![CDATA[Hier können Sie Template-Quelltext verwenden (<a href="http://www.smarty.net/">Dokumentation</a>).]]></item>
 		<item name="cms.acp.content.type.de.codequake.cms.content.type.html"><![CDATA[HTML]]></item>
 		<item name="cms.acp.content.type.de.codequake.cms.content.type.html.text"><![CDATA[HTML-Quelltext]]></item>
-		<item
-			name="cms.acp.content.type.de.codequake.cms.content.type.html.text.description"><![CDATA[Hier können Sie HTML-Quelltext verwenden (<a href="http://de.selfhtml.org/">Dokumentation</a>).]]></item>
+		<item name="cms.acp.content.type.de.codequake.cms.content.type.html.text.description"><![CDATA[Hier können Sie HTML-Quelltext verwenden (<a href="http://de.selfhtml.org/">Dokumentation</a>).]]></item>
 		<item name="cms.acp.content.type.de.codequake.cms.content.type.poll"><![CDATA[Umfrage]]></item>
 		<item name="cms.acp.content.type.de.codequake.cms.content.type.image"><![CDATA[Bild]]></item>
-		<item
-			name="cms.acp.content.type.de.codequake.cms.content.type.image.select"><![CDATA[Bild auswählen]]></item>
+		<item name="cms.acp.content.type.de.codequake.cms.content.type.image.select"><![CDATA[Bild auswählen]]></item>
 		<item name="cms.acp.content.type.de.codequake.cms.content.type.image.width"><![CDATA[Breite (in px)]]></item>
-		<item
-			name="cms.acp.content.type.de.codequake.cms.content.type.image.height"><![CDATA[Höhe (in px)]]></item>
+		<item name="cms.acp.content.type.de.codequake.cms.content.type.image.height"><![CDATA[Höhe (in px)]]></item>
 		<item name="cms.acp.content.type.de.codequake.cms.content.type.image.text"><![CDATA[Untertitel]]></item>
-		<item
-			name="cms.acp.content.type.de.codequake.cms.content.type.image.hyperlink"><![CDATA[Hyperlink]]></item>
+		<item name="cms.acp.content.type.de.codequake.cms.content.type.image.hyperlink"><![CDATA[Hyperlink]]></item>
 		<item name="cms.acp.content.type.de.codequake.cms.content.type.file"><![CDATA[Datei]]></item>
 		<item name="cms.acp.content.type.de.codequake.cms.content.type.file.fileID"><![CDATA[Datei auswählen]]></item>
 		<item name="cms.acp.content.type.de.codequake.cms.content.type.file.root"><![CDATA[Hauptverzeichnis]]></item>
 		<item name="cms.acp.content.type.de.codequake.cms.content.type.youtube"><![CDATA[Youtube]]></item>
-		<item
-			name="cms.acp.content.type.de.codequake.cms.content.type.youtube.video"><![CDATA[Video-URL]]></item>
-		<item
-			name="cms.acp.content.type.de.codequake.cms.content.type.youtube.video.error.notValid"><![CDATA[Keine gültige URL]]></item>
+		<item name="cms.acp.content.type.de.codequake.cms.content.type.youtube.video"><![CDATA[Video-URL]]></item>
+		<item name="cms.acp.content.type.de.codequake.cms.content.type.youtube.video.error.notValid"><![CDATA[Keine gültige URL]]></item>
 		<item name="cms.acp.content.type.de.codequake.cms.content.type.gallery"><![CDATA[Galerie]]></item>
-		<item
-			name="cms.acp.content.type.de.codequake.cms.content.type.gallery.images"><![CDATA[Bilder]]></item>
-		<item
-			name="cms.acp.content.type.de.codequake.cms.content.type.gallery.select"><![CDATA[Bilder auswählen]]></item>
+		<item name="cms.acp.content.type.de.codequake.cms.content.type.gallery.images"><![CDATA[Bilder]]></item>
+		<item name="cms.acp.content.type.de.codequake.cms.content.type.gallery.select"><![CDATA[Bilder auswählen]]></item>
 		<item name="cms.acp.content.type.de.codequake.cms.content.type.php"><![CDATA[PHP]]></item>
 		<item name="cms.acp.content.type.de.codequake.cms.content.type.menu"><![CDATA[Menü]]></item>
 		<item name="cms.acp.content.type.de.codequake.cms.content.type.menu.depth"><![CDATA[Tiefe der Menüstruktur]]></item>
-		<item
-			name="cms.acp.content.type.de.codequake.cms.content.type.menu.depth.description"><![CDATA[Geben Sie hier die Tiefe der Menüstrukur an. Das heißt die Anzahl der aufzulistenden Ebenen des Menüs. Soll keine Beschränkung eingerichtet werden, so geben Sie 0 an.]]></item>
+		<item name="cms.acp.content.type.de.codequake.cms.content.type.menu.depth.description"><![CDATA[Geben Sie hier die Tiefe der Menüstrukur an. Das heißt die Anzahl der aufzulistenden Ebenen des Menüs. Soll keine Beschränkung eingerichtet werden, so geben Sie 0 an.]]></item>
 		<item name="cms.acp.content.type.de.codequake.cms.content.type.menu.type"><![CDATA[Vorlage]]></item>
-		<item
-			name="cms.acp.content.type.de.codequake.cms.content.type.menu.type.children"><![CDATA[Untergeordnete Seiten]]></item>
+		<item name="cms.acp.content.type.de.codequake.cms.content.type.menu.type.children"><![CDATA[Untergeordnete Seiten]]></item>
 		<item name="cms.acp.content.type.de.codequake.cms.content.type.user"><![CDATA[Benutzer]]></item>
 		<item name="cms.acp.content.type.de.codequake.cms.content.type.user.name"><![CDATA[Benutzername]]></item>
 		<item name="cms.acp.content.type.de.codequake.cms.content.type.slideshow"><![CDATA[Slideshow]]></item>
@@ -248,12 +217,12 @@
 		<item name="cms.acp.page.homePage"><![CDATA[Startseite]]></item>
 		<item name="cms.acp.page.general"><![CDATA[Allgemein]]></item>
 		<item name="cms.acp.page.general.parentID"><![CDATA[Übergeordnete Seite]]></item>
-		<item name="cms.acp.page.general.alias"><![CDATA[URL-Alias]]></item>
+		<item name="cms.acp.page.alias"><![CDATA[Abkürzung]]></item>
 		<item name="cms.acp.page.alias.error.sort"><![CDATA[Sortierung fehlgeschlagen - Alias-Dopplung]]></item>
-		<item name="cms.acp.page.alias.error.given"><![CDATA[Ein gleichnamiger Alias existiert bereits.]]></item>
-		<item name="cms.acp.page.alias.error.invalid"><![CDATA[Kein gültiger Alias.]]></item>
-		<item name="cms.acp.page.general.alias.preview"><![CDATA[Link-Vorschau:]]></item>
-		<item name="cms.acp.page.general.alias.description"><![CDATA[Der sogenannte Alias ist eine Art Abkürzung, die später der Link zu dieser Seite sein wird. Ein Alias darf ausschließlich aus Kleinbuchstaben, Ziffern und Bindestrichen bestehen.]]></item>
+		<item name="cms.acp.page.alias.error.notUnique"><![CDATA[Auf dieser Ebene existiert bereits eine Seite, die die gleiche Abkürzung besitzt.]]></item>
+		<item name="cms.acp.page.alias.error.notValid"><![CDATA[Die eingegebene Abkürzung ist ungültig.]]></item>
+		<item name="cms.acp.page.alias.preview"><![CDATA[Link-Vorschau:]]></item>
+		<item name="cms.acp.page.alias.description"><![CDATA[Die Abkürzung darf ausschließlich aus Kleinbuchstaben, Ziffern und Bindestrichen bestehen. Bindestriche sind am Anfang und Ende der Abkürzung nicht erlaubt. Abkürzungen müssen auf ihrer jeweiligen Ebene einzigartig sein. Sollten Sie keine Abkürzung vorgeben, wird diese automatisch auf Basis des Seitentitels erstellt.]]></item>
 		<item name="cms.acp.page.general.description"><![CDATA[Beschreibung]]></item>
 		<item name="cms.acp.page.meta"><![CDATA[Meta-Informationen]]></item>
 		<item name="cms.acp.page.meta.metaDescription"><![CDATA[Meta-Beschreibung]]></item>
@@ -387,8 +356,7 @@
 		<item name="wcf.acp.group.option.admin.cms.content.canUploadAttachment"><![CDATA[Kann Dateien anhängen]]></item>
 		<item name="wcf.acp.group.option.admin.cms.content.attachmentMaxSize"><![CDATA[Maximale Dateianhangsgröße]]></item>
 		<item name="wcf.acp.group.option.admin.cms.content.maxAttachmentCount"><![CDATA[Maximale Anzahl an Dateianhängen pro Inhaltsabschnitt]]></item>
-		<item
-			name="wcf.acp.group.option.admin.cms.content.allowedAttachmentExtensions"><![CDATA[Erlaubte Dateiendungen]]></item>
+		<item name="wcf.acp.group.option.admin.cms.content.allowedAttachmentExtensions"><![CDATA[Erlaubte Dateiendungen]]></item>
 	</category>
 
 	<category name="wcf.acl.option">
@@ -443,17 +411,14 @@
 	</category>
 
 	<category name="wcf.user.recentActivity">
-		<item
-			name="wcf.user.recentActivity.de.codequake.cms.page.comment.recentActivityEvent"><![CDATA[Kommentar (Seite)]]></item>
-		<item
-			name="wcf.user.recentActivity.de.codequake.cms.page.comment.response.recentActivityEvent"><![CDATA[Antwort (Seite)]]></item>
+		<item name="wcf.user.recentActivity.de.codequake.cms.page.comment.recentActivityEvent"><![CDATA[Kommentar (Seite)]]></item>
+		<item name="wcf.user.recentActivity.de.codequake.cms.page.comment.response.recentActivityEvent"><![CDATA[Antwort (Seite)]]></item>
 	</category>
 	<category name="wcf.page">
 		<item name="wcf.page.sitemap.cms"><![CDATA[Seiten]]></item>
 	</category>
 	<category name="wcf.user.notification">
 		<item name="wcf.user.notification.de.codequake.cms"><![CDATA[CMS]]></item>
-		<item
-			name="wcf.user.notification.de.codequake.cms.page.comment.response.notification.commentResponse"><![CDATA[Neue Antwort auf einen Kommentar auf einer Seite]]></item>
+		<item name="wcf.user.notification.de.codequake.cms.page.comment.response.notification.commentResponse"><![CDATA[Neue Antwort auf einen Kommentar auf einer Seite]]></item>
 	</category>
 </language>

--- a/language/en.xml
+++ b/language/en.xml
@@ -28,13 +28,13 @@
 		<item name="cms.acp.content.css.cssClasses"><![CDATA[CSS-Classes]]></item>
 		<item name="cms.acp.content.title"><![CDATA[Title]]></item>
 		<item name="cms.acp.content.css.cssClasses.description"><![CDATA[CSS classes are neccessary for the content's appearance. Recommended is "container containerPadding". For a margin on top use "marginTop". <br />
-																		<strong>Examples:</strong>
-																		<ul>
-																		<li><pre>container</pre> - Adds a border to your content</li>
-																		<li><pre>containerPadding</pre> - Use it with container to add some padding</li>
-																		<li><pre>marginTop</pre> - Adds a margin on top</li>
-																		<li><pre>center</pre> - Centers the content</li>
-																		</ul>]]></item>
+<strong>Examples:</strong>
+<ul>
+	<li><pre>container</pre> - Adds a border to your content</li>
+	<li><pre>containerPadding</pre> - Use it with container to add some padding</li>
+	<li><pre>marginTop</pre> - Adds a margin on top</li>
+	<li><pre>center</pre> - Centers the content</li>
+</ul>]]></item>
 		<item name="cms.acp.content.list"><![CDATA[List contents]]></item>
 		<item name="cms.acp.content.edit"><![CDATA[Edit content]]></item>
 		<item name="cms.acp.content.position"><![CDATA[Position]]></item>
@@ -50,93 +50,61 @@
 		<item name="cms.acp.content.type.de.codequake.cms.content.type.text"><![CDATA[Text]]></item>
 		<item name="cms.acp.content.type.de.codequake.cms.content.type.text.text"><![CDATA[Text]]></item>
 		<item name="cms.acp.content.type.de.codequake.cms.content.type.link"><![CDATA[Hyperlink/Button]]></item>
-		<item
-			name="cms.acp.content.type.de.codequake.cms.content.type.link.type.link"><![CDATA[Hyperlink]]></item>
-		<item
-			name="cms.acp.content.type.de.codequake.cms.content.type.link.type.button"><![CDATA[Button]]></item>
-		<item
-			name="cms.acp.content.type.de.codequake.cms.content.type.link.type.smallbutton"><![CDATA[Small Button]]></item>
+		<item name="cms.acp.content.type.de.codequake.cms.content.type.link.type.link"><![CDATA[Hyperlink]]></item>
+		<item name="cms.acp.content.type.de.codequake.cms.content.type.link.type.button"><![CDATA[Button]]></item>
+		<item name="cms.acp.content.type.de.codequake.cms.content.type.link.type.smallbutton"><![CDATA[Small Button]]></item>
 		<item name="cms.acp.content.type.de.codequake.cms.content.type.link.type"><![CDATA[Pattern]]></item>
 		<item name="cms.acp.content.type.de.codequake.cms.content.type.link.text"><![CDATA[Text]]></item>
-		<item
-			name="cms.acp.content.type.de.codequake.cms.content.type.link.hyperlink"><![CDATA[Hyperlink]]></item>
+		<item name="cms.acp.content.type.de.codequake.cms.content.type.link.hyperlink"><![CDATA[Hyperlink]]></item>
 		<item name="cms.acp.content.type.de.codequake.cms.content.type.tabmenu"><![CDATA[Tabmenu]]></item>
-		<item
-			name="cms.acp.content.type.de.codequake.cms.content.type.tabmenu.description"><![CDATA[All children will be arranged in a tabmenu. The children's titles will be the titles of your tab buttons. Tab buttons need CSS-IDs for the anchors, if you don't enter a CSS-ID for each child, it will be generated automatically.]]></item>
+		<item name="cms.acp.content.type.de.codequake.cms.content.type.tabmenu.description"><![CDATA[All children will be arranged in a tabmenu. The children's titles will be the titles of your tab buttons. Tab buttons need CSS-IDs for the anchors, if you don't enter a CSS-ID for each child, it will be generated automatically.]]></item>
 		<item name="cms.acp.content.type.de.codequake.cms.content.type.dashboard"><![CDATA[Dashboardbox]]></item>
-		<item
-			name="cms.acp.content.type.de.codequake.cms.content.type.dashboard.box"><![CDATA[Choose box]]></item>
+		<item name="cms.acp.content.type.de.codequake.cms.content.type.dashboard.box"><![CDATA[Choose box]]></item>
 		<item name="cms.acp.content.type.de.codequake.cms.content.type.headline"><![CDATA[Headline]]></item>
-		<item
-			name="cms.acp.content.type.de.codequake.cms.content.type.headline.type"><![CDATA[Pattern]]></item>
-		<item
-			name="cms.acp.content.type.de.codequake.cms.content.type.headline.type.h1"><![CDATA[Headline 1]]></item>
-		<item
-			name="cms.acp.content.type.de.codequake.cms.content.type.headline.type.h2"><![CDATA[Headline 2]]></item>
-		<item
-			name="cms.acp.content.type.de.codequake.cms.content.type.headline.type.h3"><![CDATA[Headline 3]]></item>
-		<item
-			name="cms.acp.content.type.de.codequake.cms.content.type.headline.type.h4"><![CDATA[Headline 4]]></item>
-		<item
-			name="cms.acp.content.type.de.codequake.cms.content.type.headline.type.h5"><![CDATA[Headline 5]]></item>
-		<item
-			name="cms.acp.content.type.de.codequake.cms.content.type.headline.text"><![CDATA[Headline]]></item>
-		<item
-			name="cms.acp.content.type.de.codequake.cms.content.type.headline.hyperlink"><![CDATA[Hyperlink]]></item>
-		<item
-			name="cms.acp.content.type.de.codequake.cms.content.type.group.description"><![CDATA[A collection of contents.]]></item>
+		<item name="cms.acp.content.type.de.codequake.cms.content.type.headline.type"><![CDATA[Pattern]]></item>
+		<item name="cms.acp.content.type.de.codequake.cms.content.type.headline.type.h1"><![CDATA[Headline 1]]></item>
+		<item name="cms.acp.content.type.de.codequake.cms.content.type.headline.type.h2"><![CDATA[Headline 2]]></item>
+		<item name="cms.acp.content.type.de.codequake.cms.content.type.headline.type.h3"><![CDATA[Headline 3]]></item>
+		<item name="cms.acp.content.type.de.codequake.cms.content.type.headline.type.h4"><![CDATA[Headline 4]]></item>
+		<item name="cms.acp.content.type.de.codequake.cms.content.type.headline.type.h5"><![CDATA[Headline 5]]></item>
+		<item name="cms.acp.content.type.de.codequake.cms.content.type.headline.text"><![CDATA[Headline]]></item>
+		<item name="cms.acp.content.type.de.codequake.cms.content.type.headline.hyperlink"><![CDATA[Hyperlink]]></item>
+		<item name="cms.acp.content.type.de.codequake.cms.content.type.group.description"><![CDATA[A collection of contents.]]></item>
 		<item name="cms.acp.content.type.de.codequake.cms.content.type.group"><![CDATA[Content collection]]></item>
 		<item name="cms.acp.content.type.de.codequake.cms.content.type.twocolumns"><![CDATA[Two Columns]]></item>
-		<item
-			name="cms.acp.content.type.de.codequake.cms.content.type.twocolumns.width"><![CDATA[Column width]]></item>
-		<item
-			name="cms.acp.content.type.de.codequake.cms.content.type.threecolumns"><![CDATA[Three Columns]]></item>
-		<item
-			name="cms.acp.content.type.de.codequake.cms.content.type.threecolumns.width"><![CDATA[Column width]]></item>
+		<item name="cms.acp.content.type.de.codequake.cms.content.type.twocolumns.width"><![CDATA[Column width]]></item>
+		<item name="cms.acp.content.type.de.codequake.cms.content.type.threecolumns"><![CDATA[Three Columns]]></item>
+		<item name="cms.acp.content.type.de.codequake.cms.content.type.threecolumns.width"><![CDATA[Column width]]></item>
 		<item name="cms.acp.content.type.de.codequake.cms.content.type.fourcolumns"><![CDATA[Four] Columns]]></item>
-		<item
-			name="cms.acp.content.type.de.codequake.cms.content.type.fourcolumns.width"><![CDATA[Column width]]></item>
+		<item name="cms.acp.content.type.de.codequake.cms.content.type.fourcolumns.width"><![CDATA[Column width]]></item>
 		<item name="cms.acp.content.type.de.codequake.cms.content.type.template"><![CDATA[Template (Smarty)]]></item>
-		<item
-			name="cms.acp.content.type.de.codequake.cms.content.type.template.text"><![CDATA[Template-Source]]></item>
-		<item
-			name="cms.acp.content.type.de.codequake.cms.content.type.template.text.description"><![CDATA[You can use Smarty-Syntax here (<a href="http://www.smarty.net/">Documentation</a>).]]></item>
+		<item name="cms.acp.content.type.de.codequake.cms.content.type.template.text"><![CDATA[Template-Source]]></item>
+		<item name="cms.acp.content.type.de.codequake.cms.content.type.template.text.description"><![CDATA[You can use Smarty-Syntax here (<a href="http://www.smarty.net/">Documentation</a>).]]></item>
 		<item name="cms.acp.content.type.de.codequake.cms.content.type.template"><![CDATA[HTML]]></item>
-		<item
-			name="cms.acp.content.type.de.codequake.cms.content.type.template.text"><![CDATA[HTML-Source]]></item>
-		<item
-			name="cms.acp.content.type.de.codequake.cms.content.type.template.text.description"><![CDATA[You can use HTML Code here.]]></item>
+		<item name="cms.acp.content.type.de.codequake.cms.content.type.template.text"><![CDATA[HTML-Source]]></item>
+		<item name="cms.acp.content.type.de.codequake.cms.content.type.template.text.description"><![CDATA[You can use HTML Code here.]]></item>
 		<item name="cms.acp.content.type.de.codequake.cms.content.type.poll"><![CDATA[Poll]]></item>
 		<item name="cms.acp.content.type.de.codequake.cms.content.type.image"><![CDATA[Picture]]></item>
-		<item
-			name="cms.acp.content.type.de.codequake.cms.content.type.image.select"><![CDATA[Select a picture]]></item>
+		<item name="cms.acp.content.type.de.codequake.cms.content.type.image.select"><![CDATA[Select a picture]]></item>
 		<item name="cms.acp.content.type.de.codequake.cms.content.type.image.width"><![CDATA[Width (in px)]]></item>
-		<item
-			name="cms.acp.content.type.de.codequake.cms.content.type.image.height"><![CDATA[Height (in px)]]></item>
+		<item name="cms.acp.content.type.de.codequake.cms.content.type.image.height"><![CDATA[Height (in px)]]></item>
 		<item name="cms.acp.content.type.de.codequake.cms.content.type.image.text"><![CDATA[Caption]]></item>
-		<item
-			name="cms.acp.content.type.de.codequake.cms.content.type.image.hyperlink"><![CDATA[Hyperlink]]></item>
+		<item name="cms.acp.content.type.de.codequake.cms.content.type.image.hyperlink"><![CDATA[Hyperlink]]></item>
 		<item name="cms.acp.content.type.de.codequake.cms.content.type.file"><![CDATA[File]]></item>
 		<item name="cms.acp.content.type.de.codequake.cms.content.type.file.fileID"><![CDATA[Choose file]]></item>
 		<item name="cms.acp.content.type.de.codequake.cms.content.type.file.root"><![CDATA[Root]]></item>
 		<item name="cms.acp.content.type.de.codequake.cms.content.type.youtube"><![CDATA[Youtube]]></item>
-		<item
-			name="cms.acp.content.type.de.codequake.cms.content.type.youtube.video"><![CDATA[Video-URL]]></item>
-		<item
-			name="cms.acp.content.type.de.codequake.cms.content.type.youtube.video.error.notValid"><![CDATA[URL not valid]]></item>
+		<item name="cms.acp.content.type.de.codequake.cms.content.type.youtube.video"><![CDATA[Video-URL]]></item>
+		<item name="cms.acp.content.type.de.codequake.cms.content.type.youtube.video.error.notValid"><![CDATA[URL not valid]]></item>
 		<item name="cms.acp.content.type.de.codequake.cms.content.type.gallery"><![CDATA[Gallery]]></item>
-		<item
-			name="cms.acp.content.type.de.codequake.cms.content.type.gallery.images"><![CDATA[Images]]></item>
-		<item
-			name="cms.acp.content.type.de.codequake.cms.content.type.gallery.select"><![CDATA[Pick images]]></item>
+		<item name="cms.acp.content.type.de.codequake.cms.content.type.gallery.images"><![CDATA[Images]]></item>
+		<item name="cms.acp.content.type.de.codequake.cms.content.type.gallery.select"><![CDATA[Pick images]]></item>
 		<item name="cms.acp.content.type.de.codequake.cms.content.type.php"><![CDATA[PHP]]></item>
 		<item name="cms.acp.content.type.de.codequake.cms.content.type.menu"><![CDATA[Menu]]></item>
 		<item name="cms.acp.content.type.de.codequake.cms.content.type.menu.depth"><![CDATA[Menu depth]]></item>
-		<item
-			name="cms.acp.content.type.de.codequake.cms.content.type.menu.depth.description"><![CDATA[Number of listed menu levels. Type 0 for unlimited.]]></item>
+		<item name="cms.acp.content.type.de.codequake.cms.content.type.menu.depth.description"><![CDATA[Number of listed menu levels. Type 0 for unlimited.]]></item>
 		<item name="cms.acp.content.type.de.codequake.cms.content.type.menu.type"><![CDATA[Pattern]]></item>
-		<item
-			name="cms.acp.content.type.de.codequake.cms.content.type.menu.type.children"><![CDATA[Child pages]]></item>
+		<item name="cms.acp.content.type.de.codequake.cms.content.type.menu.type.children"><![CDATA[Child pages]]></item>
 		<item name="cms.acp.content.type.de.codequake.cms.content.type.user"><![CDATA[User]]></item>
 		<item name="cms.acp.content.type.de.codequake.cms.content.type.user.name"><![CDATA[Username]]></item>
 		<item name="cms.acp.content.type.de.codequake.cms.content.type.slideshow"><![CDATA[Slideshow]]></item>
@@ -250,15 +218,15 @@
 		<item name="cms.acp.page.homePage"><![CDATA[Startpage]]></item>
 		<item name="cms.acp.page.general"><![CDATA[General]]></item>
 		<item name="cms.acp.page.general.parentID"><![CDATA[Parent page]]></item>
-		<item name="cms.acp.page.general.alias"><![CDATA[URL-Alias]]></item>
+		<item name="cms.acp.page.alias"><![CDATA[URL-Alias]]></item>
 		<item name="cms.acp.page.general.menuItem"><![CDATA[Add menu item]]></item>
 		<item name="cms.acp.page.general.menuItem.description"><![CDATA[]]>
 		</item>
 		<item name="cms.acp.page.alias.error.sort"><![CDATA[Sorting failed - Existing Alias!]]></item>
-		<item name="cms.acp.page.alias.error.given"><![CDATA[Alias exists!]]></item>
-		<item name="cms.acp.page.alias.error.invalid"><![CDATA[Invalid Alias!]]></item>
-		<item name="cms.acp.page.general.alias.preview"><![CDATA[Link-Preview:]]></item>
-		<item name="cms.acp.page.general.alias.description"><![CDATA[The so called alias will be this page's link. It must not contain any other items than lowercase-letters, numbers and hyphens.]]></item>
+		<item name="cms.acp.page.alias.error.notUnique"><![CDATA[Alias exists!]]></item>
+		<item name="cms.acp.page.alias.error.notValid"><![CDATA[Invalid Alias!]]></item>
+		<item name="cms.acp.page.alias.preview"><![CDATA[Link-Preview:]]></item>
+		<item name="cms.acp.page.alias.description"><![CDATA[The so called alias will be this page's link. It must not contain any other items than lowercase-letters, numbers and hyphens.]]></item>
 		<item name="cms.acp.page.general.description"><![CDATA[Description]]></item>
 		<item name="cms.acp.page.overview"><![CDATA[Overview]]></item>
 		<item name="cms.acp.page.meta"><![CDATA[Metainfomation]]></item>
@@ -389,8 +357,7 @@
 		<item name="wcf.acp.group.option.admin.cms.content.canUploadAttachment"><![CDATA[Can attach files]]></item>
 		<item name="wcf.acp.group.option.admin.cms.content.attachmentMaxSize"><![CDATA[Maximum filesize]]></item>
 		<item name="wcf.acp.group.option.admin.cms.content.maxAttachmentCount"><![CDATA[Maximum number of attachments per content section]]></item>
-		<item
-			name="wcf.acp.group.option.admin.cms.content.allowedAttachmentExtensions"><![CDATA[Allowed file extensions]]></item>
+		<item name="wcf.acp.group.option.admin.cms.content.allowedAttachmentExtensions"><![CDATA[Allowed file extensions]]></item>
 	</category>
 
 	<category name="wcf.acl.option">
@@ -445,10 +412,8 @@
 	</category>
 
 	<category name="wcf.user.recentActivity">
-		<item
-			name="wcf.user.recentActivity.de.codequake.cms.page.comment.recentActivityEvent"><![CDATA[Comment (Page)]]></item>
-		<item
-			name="wcf.user.recentActivity.de.codequake.cms.page.comment.response.recentActivityEvent"><![CDATA[Response (Page)]]></item>
+		<item name="wcf.user.recentActivity.de.codequake.cms.page.comment.recentActivityEvent"><![CDATA[Comment (Page)]]></item>
+		<item name="wcf.user.recentActivity.de.codequake.cms.page.comment.response.recentActivityEvent"><![CDATA[Response (Page)]]></item>
 	</category>
 
 	<category name="wcf.page">
@@ -457,7 +422,6 @@
 
 	<category name="wcf.user.notification">
 		<item name="wcf.user.notification.de.codequake.cms"><![CDATA[CMS]]></item>
-		<item
-			name="wcf.user.notification.de.codequake.cms.page.comment.response.notification.commentResponse"><![CDATA[New response to a comment on a page]]></item>
+		<item name="wcf.user.notification.de.codequake.cms.page.comment.response.notification.commentResponse"><![CDATA[New response to a comment on a page]]></item>
 	</category>
 </language>


### PR DESCRIPTION
This pull request applies various changes to the alias system:
- Changed the moment an automatic alias is build based on the page title. That way, it's easier to set a custom alias.
- The build of an alias now works in multilingual systems. The alias is build based on the english page title or in case that language is not installed based on the default language.
- The alias build function now properly handles all not allowed characters. It's guaranteed that the builded alias is valid now.
- Renamed `URL-Alias` to `Abkürzung`. That's a more understandable description.
- Various minor changes including indentation fixes
