### PR TITLE
content template improvements

### DIFF
--- a/acptemplates/contentAdd.tpl
+++ b/acptemplates/contentAdd.tpl
@@ -31,7 +31,7 @@
 <div class="contentNavigation">
 	<nav>
 		<ul>
-			<li><a href="{link application='cms' controller='ContentList' object=$page}{/link}" title="{lang}cms.acp.menu.link.cms.content.list{/lang}" class="button"><span class="icon icon16 icon-list"></span> <span>{lang}cms.acp.menu.link.cms.content.list{/lang}</span></a></li>
+			<li><a href="{link application='cms' controller='ContentList' pageID=$page->pageID}{/link}" title="{lang}cms.acp.menu.link.cms.content.list{/lang}" class="button"><span class="icon icon16 icon-list"></span> <span>{lang}cms.acp.menu.link.cms.content.list{/lang}</span></a></li>
 
 			{event name='contentNavigationButtons'}
 		</ul>

--- a/acptemplates/contentList.tpl
+++ b/acptemplates/contentList.tpl
@@ -1,49 +1,60 @@
 {include file='header' pageTitle='cms.acp.content.list'}
 
-<nav class="breadcrumbs marginTop">
-	<ul>
-		<li title="{$page->getTitle()|language}" itemscope="itemscope" itemtype="http://data-vocabulary.org/Breadcrumb">
-			<a href="{link controller='PageEdit' object=$page application='cms'}{/link}" itemprop="url">
-				<span itemprop="title">{$page->getTitle()|language}</span>
-			</a>
-			<span class="pointer">
-				<span>»</span>
-			</span>
-		</li>
-	</ul>
-</nav>
+<script data-relocate="true" src="{@$__wcf->getPath('cms')}acp/js/CMS.ACP.js"></script>
+<script data-relocate="true">
+	//<![CDATA[
+	$(function() {
+		WCF.TabMenu.init();
+		new WCF.Action.NestedDelete('cms\\data\\content\\ContentAction', '.jsContentRow');
+		new WCF.Action.Toggle('cms\\data\\content\\ContentAction', '.jsContentRow', '> .sortableNodeLabel > .buttons > .jsToggleButton');
+		new WCF.Sortable.List('contentListSidebar', 'cms\\data\\content\\ContentAction');
+		new WCF.Sortable.List('contentListBody', 'cms\\data\\content\\ContentAction');
+		new CMS.ACP.Copy('.jsCopyButton', 'cms\\data\\content\\ContentAction');
+		new CMS.ACP.Page.AddContent();
+		new CMS.ACP.Content.Revisions();
+		WCF.Language.addObject({
+			{foreach from=$objectTypeList item=type}
+				'cms.acp.content.type.{$type->objectType}': '{lang}cms.acp.content.type.{$type->objectType}{/lang}',
+			{/foreach}
+			'cms.acp.content.type.content': '{lang}cms.acp.content.type.content{/lang}',
+			'cms.acp.content.revisions': '{lang}cms.acp.content.revisions{/lang}',
+			'cms.acp.content.revision.action.create': '{lang}cms.acp.content.revision.action.create{/lang}',
+			'cms.acp.content.revision.action.update': '{lang}cms.acp.content.revision.action.update{/lang}',
+			'cms.acp.content.revision.action.updatePosition': '{lang}cms.acp.content.revision.action.updatePosition{/lang}',
+			'cms.acp.content.revision.action.setAsHome': '{lang}cms.acp.content.revision.action.setAsHome{/lang}',
+			'cms.acp.content.revision.action.restore': '{lang}cms.acp.content.revision.action.restore{/lang}'
+		});
+	});
+	//]]>
+</script>
 
 <header class="boxHeadline">
 	<h1>{lang}cms.acp.content.list{/lang}</h1>
-
-	<script data-relocate="true" src="{@$__wcf->getPath('cms')}acp/js/CMS.ACP.js"></script>
-	<script data-relocate="true">
-		//<![CDATA[
-		$(function() {
-			WCF.TabMenu.init();
-			new WCF.Action.NestedDelete('cms\\data\\content\\ContentAction', '.jsContentRow');
-			new WCF.Action.Toggle('cms\\data\\content\\ContentAction', '.jsContentRow', '> .sortableNodeLabel > .buttons > .jsToggleButton');
-			new WCF.Sortable.List('contentListSidebar', 'cms\\data\\content\\ContentAction');
-			new WCF.Sortable.List('contentListBody', 'cms\\data\\content\\ContentAction');
-			new CMS.ACP.Copy('.jsCopyButton', 'cms\\data\\content\\ContentAction');
-			new CMS.ACP.Page.AddContent();
-			new CMS.ACP.Content.Revisions();
-			WCF.Language.addObject({
-				{foreach from=$objectTypeList item=type}
-					'cms.acp.content.type.{$type->objectType}': '{lang}cms.acp.content.type.{$type->objectType}{/lang}',
-				{/foreach}
-				'cms.acp.content.type.content': '{lang}cms.acp.content.type.content{/lang}',
-				'cms.acp.content.revisions': '{lang}cms.acp.content.revisions{/lang}',
-				'cms.acp.content.revision.action.create': '{lang}cms.acp.content.revision.action.create{/lang}',
-				'cms.acp.content.revision.action.update': '{lang}cms.acp.content.revision.action.update{/lang}',
-				'cms.acp.content.revision.action.updatePosition': '{lang}cms.acp.content.revision.action.updatePosition{/lang}',
-				'cms.acp.content.revision.action.setAsHome': '{lang}cms.acp.content.revision.action.setAsHome{/lang}',
-				'cms.acp.content.revision.action.restore': '{lang}cms.acp.content.revision.action.restore{/lang}'
-				});
-		});
-		//]]>
-	</script>
 </header>
+
+<form method="post" action="{link application='cms' controller='ContentList'}{/link}">
+	<div id="filterContainer" class="container containerPadding marginTop">
+		<fieldset>
+			<legend>{lang}wcf.global.filter{/lang}</legend>
+
+			<dl>
+				<dt><label for="pageID">{lang}cms.acp.page.page{/lang}</label></dt>
+				<dd>
+					<select name="pageID" id="pageID">
+						{foreach from=$pageList item=node}
+							<option value="{@$node->pageID}"{if $node->pageID == $pageID} selected="selected"{/if}>{@'&nbsp;&nbsp;&nbsp;&nbsp;'|str_repeat:$pageList->getDepth()}{$node->getTitle()|language}</option>
+						{/foreach}
+					</select>
+				</dd>
+			</dl>
+		</fieldset>
+	</div>
+
+	<div class="formSubmit">
+		<input type="submit" value="{lang}wcf.global.button.submit{/lang}" accesskey="s" />
+		{@SECURITY_TOKEN_INPUT_TAG}
+	</div>
+</form>
 
 <div class="contentNavigation">
 	<nav>
@@ -52,108 +63,114 @@
 		</ul>
 	</nav>
 </div>
-<div class="tabMenuContainer">
-<nav class="tabMenu">
-	<ul>
-		<li><a href="{@$__wcf->getAnchor('body')}">{lang}cms.acp.content.position.position.body{/lang}</a></li>
-		<li><a href="{@$__wcf->getAnchor('sidebar')}">{lang}cms.acp.content.position.position.sidebar{/lang}</a></li>
-		{event name='tabMenuTabs'}
-	</ul>
-</nav>
-<div id="body" class="tabMenuContent container containerPadding">
-{hascontent}
-	<section id="contentListBody" class="sortableListContainer">
-		<ol class="contentListBody sortableList" data-object-id="0">
-			{content}
-				{assign var=oldDepth value=0}
-				{foreach from=$contentListBody item=content}
-					{section name=i loop=$oldDepth-$contentListBody->getDepth()}</ol></li>{/section}
-					<li class="content jsContentRow sortableNode" data-object-id="{$content->contentID}">
-						<span class="sortableNodeLabel">
-							<span class="title">
-								<span class="pointer collapsibleButton icon icon16 {$content->getIcon()}"></span>
-								<a href="{link controller='ContentEdit' application='cms' object=$content objectType=$content->getTypeName()}position=body{/link}">{@$content->getTitle()|language}</a> - <small>{lang}cms.acp.content.type.{$content->getTypeName()}{/lang}</small>
-							</span>
-							<span class="statusDisplay buttons">
-								<a href="{link controller='ContentEdit' application='cms' object=$content objectType=$content->getTypeName()}{/link}" title="{lang}wcf.global.button.edit{/lang}" class="jsTooltip"><span class="icon icon16 icon-pencil"></span></a>
-								<span class="icon icon16 icon-remove jsDeleteButton jsTooltip pointer" title="{lang}wcf.global.button.delete{/lang}" data-object-id="{@$content->contentID}" data-confirm-message="{lang}cms.acp.content.delete.sure{/lang}"></span>
-								<span class="icon icon16 icon-check{if $content->isDisabled}-empty{/if} jsToggleButton jsTooltip pointer" title="{lang}wcf.global.button.{if !$content->isDisabled}disable{else}enable{/if}{/lang}" data-object-id="{@$content->contentID}"></span>
-								<span class="icon icon16 icon-plus jsContentAddButton jsTooltip pointer" title="{lang}cms.acp.page.content.add{/lang}" data-object-id="{@$content->pageID}" data-position="body" data-parent-id="{$content->contentID}"></span>
-								<span class="icon icon16 icon-copy jsCopyButton jsTooltip pointer" title="{lang}cms.acp.content.copy{/lang}" data-object-id="{@$content->contentID}"></span>
-								<span class="icon icon16 icon-tasks jsRevisionsButton jsTooltip pointer" title="{lang}cms.acp.page.revisions{/lang}" data-object-id="{@$content->contentID}"></span>
 
-								{event name='itemButtons'}
-							</span>
-						</span>
-						<ol class="contentListBody sortableList" data-object-id="{@$content->contentID}">
-						{if !$contentListBody->current()->hasChildren()}
-							</ol></li>
-						{/if}
-						{assign var=oldDepth value=$contentListBody->getDepth()}
-				{/foreach}
-				{section name=i loop=$oldDepth}</ol></li>{/section}
-			{/content}
-		</ol>
-	</section>
-	<div class="formSubmit">
-			<button class="button buttonPrimary" data-type="submit">{lang}wcf.global.button.saveSorting{/lang}</button>
-			<button class="button jsContentAddButton jsTooltip pointer" data-object-id="{$page->pageID}" data-position="body" title="{lang}cms.acp.content.add{/lang}"><span class="icon icon16 icon-plus"></span> <span>{lang}cms.acp.content.add{/lang}</span></button>
-	</div>
-{hascontentelse}
-	<p class="info">{lang}wcf.global.noItems{/lang}</p>
-	<div class="formSubmit">
-			<button class="button jsContentAddButton jsTooltip pointer" data-object-id="{$page->pageID}" data-position="body" title="{lang}cms.acp.content.add{/lang}"><span class="icon icon16 icon-plus"></span> <span>{lang}cms.acp.content.add{/lang}</span></button>
-	</div>
-{/hascontent}
-</div>
+{if $pageID}
+	<div class="tabMenuContainer">
+		<nav class="tabMenu">
+			<ul>
+				<li><a href="{@$__wcf->getAnchor('body')}">{lang}cms.acp.content.position.position.body{/lang}</a></li>
+				<li><a href="{@$__wcf->getAnchor('sidebar')}">{lang}cms.acp.content.position.position.sidebar{/lang}</a></li>
 
-<div id="sidebar" class="tabMenuContent container containerPadding">
-{hascontent}
-	<section id="contentListSidebar" class="sortableListContainer">
-		<ol class="contentListSidebar sortableList" data-object-id="0">
-			{content}
-				{assign var=oldDepth value=0}
-				{foreach from=$contentListSidebar item=content}
-					{section name=i loop=$oldDepth-$contentListSidebar->getDepth()}</ol></li>{/section}
-					<li class="content jsContentRow sortableNode" data-object-id="{$content->contentID}">
-						<span class="sortableNodeLabel">
-							<span class="title">
-								<span class="pointer collapsibleButton icon icon16 {$content->getIcon()}"></span>
-								<a href="{link controller='ContentEdit' application='cms' object=$content objectType=$content->getTypeName()}position=sidebar{/link}">{@$content->getTitle()|language}</a> - <small>{lang}cms.acp.content.type.{$content->getTypeName()}{/lang}</small>
-							</span>
-							<span class="statusDisplay buttons">
-								<a href="{link controller='ContentEdit' application='cms' object=$content objectType=$content->getTypeName()}{/link}" title="{lang}wcf.global.button.edit{/lang}" class="jsTooltip"><span class="icon icon16 icon-pencil"></span></a>
-								<span class="icon icon16 icon-remove jsDeleteButton jsTooltip pointer" title="{lang}wcf.global.button.delete{/lang}" data-object-id="{@$content->contentID}" data-confirm-message="{lang}cms.acp.content.delete.sure{/lang}"></span>
-								<span class="icon icon16 icon-plus jsContentAddButton jsTooltip pointer" title="{lang}cms.acp.page.content.add{/lang}" data-object-id="{@$content->pageID}" data-position="sidebar" data-parent-id="{$content->contentID}"></span>
-								<span class="icon icon16 icon-copy jsCopyButton jsTooltip pointer" title="{lang}cms.acp.content.copy{/lang}" data-object-id="{@$content->contentID}"></span>
-								<span class="icon icon16 icon-tasks jsRevisionsButton jsTooltip pointer" title="{lang}cms.acp.page.revisions{/lang}" data-object-id="{@$content->contentID}"></span>
+				{event name='tabMenuTabs'}
+			</ul>
+		</nav>
 
-								{event name='itemButtons'}
-							</span>
-						</span>
-						<ol class="contentListSidebar sortableList" data-object-id="{@$content->contentID}">
-						{if !$contentListSidebar->current()->hasChildren()}
-							</ol></li>
-						{/if}
-						{assign var=oldDepth value=$contentListSidebar->getDepth()}
-				{/foreach}
-				{section name=i loop=$oldDepth}</ol></li>{/section}
-			{/content}
-		</ol>
-	</section>
-	<div class="formSubmit">
-			<button class="button buttonPrimary" data-type="submit">{lang}wcf.global.button.saveSorting{/lang}</button>
-			<button class="button jsContentAddButton jsTooltip pointer" data-object-id="{$page->pageID}" data-position="sidebar" title="{lang}cms.acp.content.add{/lang}"><span class="icon icon16 icon-plus"></span> <span>{lang}cms.acp.content.add{/lang}</span></button>
-	</div>
-{hascontentelse}
-	<p class="info">{lang}wcf.global.noItems{/lang}</p>
-	<div class="formSubmit">
-			<button class="button jsContentAddButton jsTooltip pointer" data-object-id="{$page->pageID}" data-position="sidebar" title="{lang}cms.acp.content.add{/lang}"><span class="icon icon16 icon-plus"></span> <span>{lang}cms.acp.content.add{/lang}</span></button>
-	</div>
-{/hascontent}
-</div>
+		<div id="body" class="tabMenuContent container containerPadding">
+			{hascontent}
+				<section id="contentListBody" class="sortableListContainer">
+					<ol class="contentListBody sortableList" data-object-id="0">
+						{content}
+							{assign var=oldDepth value=0}
+							{foreach from=$contentListBody item=content}
+								{section name=i loop=$oldDepth-$contentListBody->getDepth()}</ol></li>{/section}
+								<li class="content jsContentRow sortableNode" data-object-id="{$content->contentID}">
+									<span class="sortableNodeLabel">
+										<span class="title">
+											<span class="pointer collapsibleButton icon icon16 {$content->getIcon()}"></span>
+											<a href="{link controller='ContentEdit' application='cms' object=$content objectType=$content->getTypeName()}position=body{/link}">{@$content->getTitle()|language}</a> - <small>{lang}cms.acp.content.type.{$content->getTypeName()}{/lang}</small>
+										</span>
+										<span class="statusDisplay buttons">
+											<a href="{link controller='ContentEdit' application='cms' object=$content objectType=$content->getTypeName()}{/link}" title="{lang}wcf.global.button.edit{/lang}" class="jsTooltip"><span class="icon icon16 icon-pencil"></span></a>
+											<span class="icon icon16 icon-remove jsDeleteButton jsTooltip pointer" title="{lang}wcf.global.button.delete{/lang}" data-object-id="{@$content->contentID}" data-confirm-message="{lang}cms.acp.content.delete.sure{/lang}"></span>
+											<span class="icon icon16 icon-check{if $content->isDisabled}-empty{/if} jsToggleButton jsTooltip pointer" title="{lang}wcf.global.button.{if !$content->isDisabled}disable{else}enable{/if}{/lang}" data-object-id="{@$content->contentID}"></span>
+											<span class="icon icon16 icon-plus jsContentAddButton jsTooltip pointer" title="{lang}cms.acp.page.content.add{/lang}" data-object-id="{@$content->pageID}" data-position="body" data-parent-id="{$content->contentID}"></span>
+											<span class="icon icon16 icon-copy jsCopyButton jsTooltip pointer" title="{lang}cms.acp.content.copy{/lang}" data-object-id="{@$content->contentID}"></span>
+											<span class="icon icon16 icon-tasks jsRevisionsButton jsTooltip pointer" title="{lang}cms.acp.page.revisions{/lang}" data-object-id="{@$content->contentID}"></span>
 
-<div class="container marginTop">
+											{event name='itemButtons'}
+										</span>
+									</span>
+									<ol class="contentListBody sortableList" data-object-id="{@$content->contentID}">
+									{if !$contentListBody->current()->hasChildren()}
+										</ol></li>
+									{/if}
+									{assign var=oldDepth value=$contentListBody->getDepth()}
+							{/foreach}
+							{section name=i loop=$oldDepth}</ol></li>{/section}
+						{/content}
+					</ol>
+				</section>
+
+				<div class="formSubmit">
+						<button class="button buttonPrimary" data-type="submit">{lang}wcf.global.button.saveSorting{/lang}</button>
+						<button class="button jsContentAddButton jsTooltip pointer" data-object-id="{$page->pageID}" data-position="body" title="{lang}cms.acp.content.add{/lang}"><span class="icon icon16 icon-plus"></span> <span>{lang}cms.acp.content.add{/lang}</span></button>
+				</div>
+			{hascontentelse}
+				<p class="info">{lang}wcf.global.noItems{/lang}</p>
+				<div class="formSubmit">
+						<button class="button jsContentAddButton jsTooltip pointer" data-object-id="{$page->pageID}" data-position="body" title="{lang}cms.acp.content.add{/lang}"><span class="icon icon16 icon-plus"></span> <span>{lang}cms.acp.content.add{/lang}</span></button>
+				</div>
+			{/hascontent}
+		</div>
+
+		<div id="sidebar" class="tabMenuContent container containerPadding">
+			{hascontent}
+				<section id="contentListSidebar" class="sortableListContainer">
+					<ol class="contentListSidebar sortableList" data-object-id="0">
+						{content}
+							{assign var=oldDepth value=0}
+							{foreach from=$contentListSidebar item=content}
+								{section name=i loop=$oldDepth-$contentListSidebar->getDepth()}</ol></li>{/section}
+								<li class="content jsContentRow sortableNode" data-object-id="{$content->contentID}">
+									<span class="sortableNodeLabel">
+										<span class="title">
+											<span class="pointer collapsibleButton icon icon16 {$content->getIcon()}"></span>
+											<a href="{link controller='ContentEdit' application='cms' object=$content objectType=$content->getTypeName()}position=sidebar{/link}">{@$content->getTitle()|language}</a> - <small>{lang}cms.acp.content.type.{$content->getTypeName()}{/lang}</small>
+										</span>
+										<span class="statusDisplay buttons">
+											<a href="{link controller='ContentEdit' application='cms' object=$content objectType=$content->getTypeName()}{/link}" title="{lang}wcf.global.button.edit{/lang}" class="jsTooltip"><span class="icon icon16 icon-pencil"></span></a>
+											<span class="icon icon16 icon-remove jsDeleteButton jsTooltip pointer" title="{lang}wcf.global.button.delete{/lang}" data-object-id="{@$content->contentID}" data-confirm-message="{lang}cms.acp.content.delete.sure{/lang}"></span>
+											<span class="icon icon16 icon-plus jsContentAddButton jsTooltip pointer" title="{lang}cms.acp.page.content.add{/lang}" data-object-id="{@$content->pageID}" data-position="sidebar" data-parent-id="{$content->contentID}"></span>
+											<span class="icon icon16 icon-copy jsCopyButton jsTooltip pointer" title="{lang}cms.acp.content.copy{/lang}" data-object-id="{@$content->contentID}"></span>
+											<span class="icon icon16 icon-tasks jsRevisionsButton jsTooltip pointer" title="{lang}cms.acp.page.revisions{/lang}" data-object-id="{@$content->contentID}"></span>
+
+											{event name='itemButtons'}
+										</span>
+									</span>
+									<ol class="contentListSidebar sortableList" data-object-id="{@$content->contentID}">
+									{if !$contentListSidebar->current()->hasChildren()}
+										</ol></li>
+									{/if}
+									{assign var=oldDepth value=$contentListSidebar->getDepth()}
+							{/foreach}
+							{section name=i loop=$oldDepth}</ol></li>{/section}
+						{/content}
+					</ol>
+				</section>
+				<div class="formSubmit">
+						<button class="button buttonPrimary" data-type="submit">{lang}wcf.global.button.saveSorting{/lang}</button>
+						<button class="button jsContentAddButton jsTooltip pointer" data-object-id="{$page->pageID}" data-position="sidebar" title="{lang}cms.acp.content.add{/lang}"><span class="icon icon16 icon-plus"></span> <span>{lang}cms.acp.content.add{/lang}</span></button>
+				</div>
+			{hascontentelse}
+				<p class="info">{lang}wcf.global.noItems{/lang}</p>
+				<div class="formSubmit">
+					<button class="button jsContentAddButton jsTooltip pointer" data-object-id="{$page->pageID}" data-position="sidebar" title="{lang}cms.acp.content.add{/lang}"><span class="icon icon16 icon-plus"></span> <span>{lang}cms.acp.content.add{/lang}</span></button>
+				</div>
+			{/hascontent}
+		</div>
+	</div>
+
+	<div class="container marginTop">
 		<ol class="containerList infoBoxList">
 			<li class="box32">
 				<span class="icon icon32 icon-question-sign"></span>
@@ -170,6 +187,7 @@
 				</ul>
 			</li>
 		</ol>
-</div>
+	</div>
+{/if}
 
 {include file='footer'}

--- a/acptemplates/pageList.tpl
+++ b/acptemplates/pageList.tpl
@@ -90,7 +90,7 @@
 								<span class="icon icon16 icon-tasks jsRevisionsButton jsTooltip pointer" title="{lang}cms.acp.page.revisions{/lang}" data-object-id="{@$page->pageID}"></span>
 								<!-- content controls -->
 								<span class="icon icon16 icon-plus jsContentAddButton jsTooltip pointer" title="{lang}cms.acp.page.content.add{/lang}" data-object-id="{@$page->pageID}"></span>
-								<a href="{link controller='ContentList' id=$page->pageID application='cms'}{/link}" title="{lang}cms.acp.page.content.list{/lang}" class="jsTooltip"><span class="icon icon16 icon-file"></span></a>
+								<a href="{link controller='ContentList' pageID=$page->pageID application='cms'}{/link}" title="{lang}cms.acp.page.content.list{/lang}" class="jsTooltip"><span class="icon icon16 icon-file"></span></a>
 							{event name='itemButtons'}
 							</span>
 						</span>
@@ -124,7 +124,7 @@
 					<li><span class="icon icon16 icon-copy"></span> <span>{lang}cms.acp.page.copy{/lang}</span></li>
 					<li><span class="icon icon16 icon-tasks"></span> <span>{lang}cms.acp.page.revisions{/lang}</span></li>
 					<li><span class="icon icon16 icon-plus"></span> <span>{lang}cms.acp.content.add{/lang}</span></li>
-					<li><span class="icon icon16 icon-file"></span> <span>{lang}cms.acp.content.listing{/lang}</span></li>
+					<li><span class="icon icon16 icon-file"></span> <span>{lang}cms.acp.content.list{/lang}</span></li>
 				</ul>
 			</li>
 			<li class="box32">

--- a/language/de.xml
+++ b/language/de.xml
@@ -21,8 +21,7 @@
 		<item name="cms.acp.content.general"><![CDATA[Allgemein]]></item>
 		<item name="cms.acp.content.general.pageID"><![CDATA[Seite auswählen]]></item>
 		<item name="cms.acp.content.general.title"><![CDATA[Titel]]></item>
-		<item name="cms.acp.content.list"><![CDATA[Inhalte von '{$page->title|language}']]></item>
-		<item name="cms.acp.content.listing"><![CDATA[Inhalte auflisten]]></item>
+		<item name="cms.acp.content.list"><![CDATA[Inhalte auflisten]]></item>
 		<item name="cms.acp.content.position"><![CDATA[Position]]></item>
 		<item name="cms.acp.content.position.parentID"><![CDATA[Übergeordneter Inhalt]]></item>
 		<item name="cms.acp.content.position.position.body"><![CDATA[Inhaltsbereich]]></item>
@@ -194,7 +193,7 @@
 		<item name="cms.acp.page.import.info"><![CDATA[Unmittelbar nach dem Hochladen der Sicherungsdatei werden alle Daten gelöscht um sie mit den Daten aus dem Archiv zu ersetzen. Diese Aktion kann nicht rückgängig gemacht werden. Ein Datenimport ist nur von CMS Version 2.0.0 aufwärts oder mit Konvertierungsplugin auch von CMS Version 1.1.2 pl 2 möglich. Der Import kann besonders bei großen Datenmengen eine Zeit lang dauern, schließen Sie auf keinen Fall das Fenster und achten Sie darauf, dass das Limit für Dateigrößen beim Upload in der php.ini ausreichend hoch gesetzt ist.]]></item>
 		<item name="cms.acp.page.import.tar"><![CDATA[Archiv]]></item>
 		<item name="cms.acp.page.legend"><![CDATA[Legende]]></item>
-		<item name="cms.acp.page.list"><![CDATA[Seiten]]></item>
+		<item name="cms.acp.page.list"><![CDATA[Seiten auflisten]]></item>
 		<item name="cms.acp.page.list.description"><![CDATA[Seiten bilden die Grundlage des Fireball CMS. Erstellen Sie eine Seite um dieser später Inhalte verschiedener Typen zuordnen zu können.]]></item>
 		<item name="cms.acp.page.menuItem.error.exists"><![CDATA[Es existiert bereits ein Menüpunkt mit gleichem Bezeichner. Aus technischen Gründen ist es nicht möglich einen weiteren Menüpunkt zu erstellen.]]></item>
 		<item name="cms.acp.page.meta"><![CDATA[Meta-Informationen]]></item>
@@ -206,6 +205,7 @@
 		<item name="cms.acp.page.meta.robots.noindexfollow"><![CDATA[Seite nicht indizieren, aber Links folgen]]></item>
 		<item name="cms.acp.page.meta.robots.noindexnofollow"><![CDATA[Seite nicht indizieren und keinem Link folgen]]></item>
 		<item name="cms.acp.page.metaDescription.description"><![CDATA[Das meta-Element Attribut “description” wird laut Google nicht zur Berechnung des Rankings ausgewertet, ist aber maßgeblich für die CTR (Click-Through-Rate) von Usern ausschlaggebend und sollte demnach Beachtung finden.]]></item>
+		<item name="cms.acp.page.page"><![CDATA[Seite]]></item>
 		<item name="cms.acp.page.position"><![CDATA[Position]]></item>
 		<item name="cms.acp.page.position.description"><![CDATA[Legt die Reihenfolge fest, in der die Seiten aufgelistet werden.]]></item>
 		<item name="cms.acp.page.position.invisible"><![CDATA[Seite verstecken]]></item>
@@ -257,7 +257,7 @@
 		<item name="cms.acp.stylesheet.general"><![CDATA[Allgemeine Einstellungen]]></item>
 		<item name="cms.acp.stylesheet.less"><![CDATA[CSS & Less]]></item>
 		<item name="cms.acp.stylesheet.less.description"><![CDATA[Die Eingabe kann vollständig aus CSS bestehen. Sie haben zusätzlich den Zugriff auf LESS und alle von Community Framework zur Verfügung gestellten Mixins.]]></item>
-		<item name="cms.acp.stylesheet.list"><![CDATA[Stylesheets]]></item>
+		<item name="cms.acp.stylesheet.list"><![CDATA[Stylesheets auflisten]]></item>
 		<item name="cms.acp.stylesheet.list.description"><![CDATA[Stylesheets oder auch Cascading Stylesheets werden zur individuellen Gestaltung von CMS Seiten benutzt - dazu werden Sie einer Seite zugewiesen. Zum Erlernen empfiehlt sich das <a href="http://www.w3schools.com/css/default.asp">CSS Tutorial von W3Schools</a>.]]></item>
 		<item name="cms.acp.stylesheet.title"><![CDATA[Titel]]></item>
 	</category>

--- a/language/en.xml
+++ b/language/en.xml
@@ -22,7 +22,6 @@
 		<item name="cms.acp.content.general.pageID"><![CDATA[Page]]></item>
 		<item name="cms.acp.content.general.title"><![CDATA[Title]]></item>
 		<item name="cms.acp.content.list"><![CDATA[List contents]]></item>
-		<item name="cms.acp.content.listing"><![CDATA[List contents]]></item>
 		<item name="cms.acp.content.position"><![CDATA[Position]]></item>
 		<item name="cms.acp.content.position.parentID"><![CDATA[Parent content]]></item>
 		<item name="cms.acp.content.position.position.body"><![CDATA[Body]]></item>


### PR DESCRIPTION
This pull request applies some changes to the content templates for better usability. **Please do not merge this pull request yet since further commits regarding the content form template are planed.**
## Content List

![unknown-1](https://cloud.githubusercontent.com/assets/2105496/3934495/f25c7a14-248b-11e4-9792-89c57f85cca3.png)
I replaced the breadcrumb navigation by a filter form. That way, administrators can easily navigate between the contents of different pages while it remains the clarification to which page the currently visible content is assigned to.
