### PR TITLE
fix issue with sitemap

### DIFF
--- a/files/lib/system/sitemap/CMSSitemapProvider.class.php
+++ b/files/lib/system/sitemap/CMSSitemapProvider.class.php
@@ -12,14 +12,20 @@ use wcf\system\WCF;
  * @package	de.codequake.cms
  */
 class CMSSitemapProvider implements ISitemapProvider {
-
+	/**
+	 * @see	\wcf\system\sitemap\ISitemapProvider::getTemplate()
+	 */
 	public function getTemplate() {
-		$list = new PageNodeTree(0);
-		
+		$nodeTree = new PageNodeTree(0);
+		$nodeList = $nodeTree->getIterator();
+
+		// sitemap only supports up to child-child-pages
+		$nodeList->setMaxDepth(2);
+
 		WCF::getTPL()->assign(array(
 			'pageList' => $list->getIterator()
 		));
-		
+
 		return WCF::getTPL()->fetch('cmsSitemap', 'cms');
 	}
 }


### PR DESCRIPTION
The Sitemap only supports a max indentation of three. The other pages are simply not indented further. Therefore, the sitemap should only contain up to child-child-pages
