### PR TITLE
content types can read own parameters

### DIFF
--- a/files/lib/system/content/type/AbstractContentType.class.php
+++ b/files/lib/system/content/type/AbstractContentType.class.php
@@ -2,6 +2,7 @@
 namespace cms\system\content\type;
 
 use cms\data\content\Content;
+use wcf\system\language\I18nHandler;
 
 /**
  * Abstract content type implementation.
@@ -21,11 +22,6 @@ abstract class AbstractContentType implements IContentType {
 	public $multilingualFields = array();
 
 	/**
-	 * @see cms\system\content\type\IContentType::validate()
-	 */
-	public function validate($data) {}
-
-	/**
 	 * @see \cms\system\content\type\IContentType::getOutput()
 	 */
 	public function getOutput(Content $content) {
@@ -38,6 +34,26 @@ abstract class AbstractContentType implements IContentType {
 	public function getIcon() {
 		return $this->icon;
 	}
+
+	/**
+	 * @see	\cms\system\content\type\IContentType::readParameters()
+	 */
+	public function readParameters() {
+		// register multilingual fields
+		foreach ($this->multilingualFields as $field) {
+			I18nHandler::getInstance()->register($field);
+		}
+	}
+
+	/**
+	 * @see	\cms\system\content\type\IContentType::readFormParameters()
+	 */
+	public function readFormParameters() { }
+
+	/**
+	 * @see cms\system\content\type\IContentType::validate()
+	 */
+	public function validate($data) { }
 
 	/**
 	 * @see \cms\system\content\type\IContentType::getFormTemplate()

--- a/files/lib/system/content/type/IContentType.class.php
+++ b/files/lib/system/content/type/IContentType.class.php
@@ -13,12 +13,6 @@ use cms\data\content\Content;
  */
 interface IContentType {
 	/**
-	 * Validates the submitted form data. In case of invalid inputs, throw
-	 * an instance of '\wcf\system\exception\UserInputException'
-	 */
-	public function validate($data);
-
-	/**
 	 * Returns the formatted output for the given content.
 	 * 
 	 * @param	\cms\data\content\Content	$content
@@ -32,6 +26,22 @@ interface IContentType {
 	 * @return	string
 	 */
 	public function getIcon();
+
+	/**
+	 * Reads content type specific parameters.
+	 */
+	public function readParameters();
+
+	/**
+	 * Reads content type specific form parameters.
+	 */
+	public function readFormParameters();
+
+	/**
+	 * Validates the submitted form data. In case of invalid inputs, throw
+	 * an instance of '\wcf\system\exception\UserInputException'
+	 */
+	public function validate($data);
 
 	/**
 	 * Returns the template name for the acp forms

--- a/files/lib/system/content/type/PollContentType.class.php
+++ b/files/lib/system/content/type/PollContentType.class.php
@@ -2,6 +2,7 @@
 namespace cms\system\content\type;
 
 use cms\data\content\Content;
+use wcf\system\poll\PollManager;
 use wcf\system\WCF;
 
 /**
@@ -16,12 +17,41 @@ class PollContentType extends AbstractContentType {
 	 */
 	protected $icon = 'icon-bar-chart';
 
-	public function getFormTemplate() {
-		return 'pollContentType';
-	}
-
+	/**
+	 * @see	\cms\system\content\type\IContentType::getOutput()
+	 */
 	public function getOutput(Content $content) {
 		WCF::getTPL()->assign('poll', $content->getPoll());
 		return WCF::getTPL()->fetch('poll', 'wcf');
+	}
+
+	/**
+	 * @see	\cms\system\content\type\IContentType::readParameters()
+	 */
+	public function readParameters() {
+		parent::readParameters();
+
+		PollManager::getInstance()->setObject('de.codequake.cms.content', 0);
+	}
+
+	/**
+	 * @see	\cms\system\content\type\IContentType::readFormParameters()
+	 */
+	public function readFormParameters() {
+		PollManager::getInstance()->readFormParameters();
+	}
+
+	/**
+	 * @see	\cms\system\content\type\IContentType::validate()
+	 */
+	public function validate($data) {
+		PollManager::getInstance()->validate();
+	}
+
+	/**
+	 * @see	\cms\system\content\type\IcontentType::getFormTemplate()
+	 */
+	public function getFormTemplate() {
+		return 'pollContentType';
 	}
 }


### PR DESCRIPTION
With this changes, content types can now read their specific (form)
parameters easier.
That way, third parties may get along without event listeners on
`\cms\acp\form\ContentAddForm` for more complex content types.
