### PR TITLE
fix typo in variable name

### DIFF
--- a/files/lib/system/sitemap/CMSSitemapProvider.class.php
+++ b/files/lib/system/sitemap/CMSSitemapProvider.class.php
@@ -23,7 +23,7 @@ class CMSSitemapProvider implements ISitemapProvider {
 		$nodeList->setMaxDepth(2);
 
 		WCF::getTPL()->assign(array(
-			'pageList' => $list->getIterator()
+			'pageList' => $nodeList->getIterator()
 		));
 
 		return WCF::getTPL()->fetch('cmsSitemap', 'cms');


### PR DESCRIPTION
I overlooked a variable usage when I renamed the variable `$list` to `$nodeList` with #61
