### PR TITLE
check whether an content type is available to add

### DIFF
--- a/files/lib/acp/form/ContentAddForm.class.php
+++ b/files/lib/acp/form/ContentAddForm.class.php
@@ -9,6 +9,7 @@ use cms\data\page\Page;
 use cms\data\page\PageAction;
 use wcf\data\object\type\ObjectTypeCache;
 use wcf\form\AbstractForm;
+use wcf\system\exception\IllegalLinkException;
 use wcf\system\exception\UserInputException;
 use wcf\system\language\I18nHandler;
 use wcf\system\poll\PollManager;
@@ -113,7 +114,11 @@ class ContentAddForm extends AbstractForm {
 		if (isset($_REQUEST['position'])) $this->position = StringUtil::trim($_REQUEST['position']);
 		if (isset($_REQUEST['parentID'])) $this->parentID = intval($_REQUEST['parentID']);
 		if ($this->parentID == 0) $this->parentID = null;
+
 		if (isset($_REQUEST['objectType'])) $this->objectType = ObjectTypeCache::getInstance()->getObjectTypeByName('de.codequake.cms.content.type', $_REQUEST['objectType']);
+		if ($this->objectType === null || !$this->objectType->getProcessor()->isAvailableToAdd()) {
+			throw new IllegalLinkException();
+		}
 
 		// read object type specific parameters
 		$this->objectType->getProcessor()->readParameters();

--- a/files/lib/data/page/PageAction.class.php
+++ b/files/lib/data/page/PageAction.class.php
@@ -296,10 +296,17 @@ class PageAction extends AbstractDatabaseObjectAction implements IClipboardActio
 	 */
 	public function getContentTypes() {
 		$types = ObjectTypeCache::getInstance()->getObjectTypes('de.codequake.cms.content.type');
+		foreach ($types as $key => $type) {
+			if (!$type->getProcessor()->isAvailableToAdd()) {
+				unset($types[$key]);
+			}
+		}
+
 		$categories = array();
 		foreach ($types as $type) {
 			$categories[$type->category] = array();
 		}
+
 		foreach ($types as $type) {
 			if ($this->parameters['position'] == 'body' && $type->allowcontent) array_push($categories[$type->category], $type);
 			if ($this->parameters['position'] == 'sidebar' && $type->allowsidebar) array_push($categories[$type->category], $type);

--- a/files/lib/system/content/type/AbstractContentType.class.php
+++ b/files/lib/system/content/type/AbstractContentType.class.php
@@ -36,6 +36,13 @@ abstract class AbstractContentType implements IContentType {
 	}
 
 	/**
+	 * @see	\cms\system\content\type\IContentType::isAvailableToAdd()
+	 */
+	public function isAvailableToAdd() {
+		return true;
+	}
+
+	/**
 	 * @see	\cms\system\content\type\IContentType::readParameters()
 	 */
 	public function readParameters() {

--- a/files/lib/system/content/type/FileContentType.class.php
+++ b/files/lib/system/content/type/FileContentType.class.php
@@ -19,6 +19,16 @@ class FileContentType extends AbstractContentType {
 	 */
 	protected $icon = 'icon-file';
 
+	/**
+	 * @see	\cms\system\content\type\IContentType::isAvailableToAdd()
+	 */
+	public function isAvailableToAdd() {
+		$fileList = new FileList();
+		$count = $fileList->countObjects();
+
+		return $count > 0;
+	}
+
 	public function getFormTemplate() {
 		$list = new FileList();
 		$list->getConditionBuilder()->add('file.folderID =  ?', array(

--- a/files/lib/system/content/type/IContentType.class.php
+++ b/files/lib/system/content/type/IContentType.class.php
@@ -28,6 +28,14 @@ interface IContentType {
 	public function getIcon();
 
 	/**
+	 * Returns whether it's currently possible to create a content of this
+	 * type.
+	 * 
+	 * @return	boolean
+	 */
+	public function isAvailableToAdd();
+
+	/**
 	 * Reads content type specific parameters.
 	 */
 	public function readParameters();


### PR DESCRIPTION
This pull request adds a new method to content types to specify whether it is currently possible to create a new content of a specific content type.
Currently, it is only used for the file content type. As long as no files are uploaded, the content type wouldn't be listed in the content type list.
