### PR TITLE
page node tree improvements

### DIFF
--- a/files/lib/acp/page/ContentListPage.class.php
+++ b/files/lib/acp/page/ContentListPage.class.php
@@ -62,7 +62,7 @@ class ContentListPage extends AbstractPage {
 	public function readData() {
 		parent::readData();
 
-		$pageNodeTree = new PageNodeTree(0, 1);
+		$pageNodeTree = new PageNodeTree();
 		$this->pageList = $pageNodeTree->getIterator();
 
 		$this->contentListBody = new DrainedPositionContentNodeTree(null, $this->pageID, null, 'body', 1);

--- a/files/lib/acp/page/PageListPage.class.php
+++ b/files/lib/acp/page/PageListPage.class.php
@@ -36,7 +36,7 @@ class PageListPage extends AbstractPage {
 	public function readData() {
 		parent::readData();
 
-		$this->pageList = new PageNodeTree(0, 1);
+		$this->pageList = new PageNodeTree();
 		$this->objectTypeList = ObjectTypeCache::getInstance()->getObjectTypes('de.codequake.cms.content.type');
 
 	}

--- a/files/lib/data/page/AccessiblePageNodeTree.class.php
+++ b/files/lib/data/page/AccessiblePageNodeTree.class.php
@@ -1,0 +1,25 @@
+<?php
+namespace cms\data\page;
+
+/**
+ * Generates a tree of accessible pages. Pages are considered as accessible
+ * when they are viewable and the current user has the permission to access the
+ * page.
+ * 
+ * @author	Florian Frantzen
+ * @copyright	2014 codeQuake
+ * @license	GNU Lesser General Public License <http://www.gnu.org/licenses/lgpl-3.0.txt>
+ * @package	de.codequake.cms
+ */
+class AccessiblePageNodeTree extends ViewablePageNodeTree {
+	/**
+	 * @see	\cms\data\page\PageNodeTree::isIncluded()
+	 */
+	protected function isIncluded(PageNode $pageNode) {
+		if (!$pageNode->isAccessible()) {
+			return false;
+		}
+
+		return parent::isIncluded($pageNode);
+	}
+}

--- a/files/lib/data/page/DrainedPageNodeTree.class.php
+++ b/files/lib/data/page/DrainedPageNodeTree.class.php
@@ -2,6 +2,8 @@
 namespace cms\data\page;
 
 /**
+ * Generates a filtered tree of all pages.
+ * 
  * @author	Jens Krumsieck
  * @copyright	2014 codeQuake
  * @license	GNU Lesser General Public License <http://www.gnu.org/licenses/lgpl-3.0.txt>
@@ -12,12 +14,18 @@ class DrainedPageNodeTree extends PageNodeTree {
 	public $drainedID = null;
 
 	public function __construct($parentID = null, $drainedID = null) {
-		$this->drainedID = $drainedID;
 		$this->parentID = $parentID;
+		$this->drainedID = $drainedID;
 	}
 
+	/**
+	 * @see	\cms\data\page\PageNodeTree::isIncluded()
+	 */
 	public function isIncluded(PageNode $pageNode) {
-		if ($pageNode->pageID == $this->drainedID) return false;
+		if ($pageNode->pageID == $this->drainedID) {
+			return false;
+		}
+
 		return parent::isIncluded($pageNode);
 	}
 }

--- a/files/lib/data/page/Page.class.php
+++ b/files/lib/data/page/Page.class.php
@@ -99,7 +99,7 @@ class Page extends CMSDatabaseObject implements IRouteController, ILinkableObjec
 	}
 
 	public function getChildrenTree($maxDepth = -1) {
-		$tree = new PageNodeTree($this->pageID);
+		$tree = new AccessiblePageNodeTree($this->pageID);
 		$tree = $tree->getIterator();
 		if ($maxDepth >= 0) $tree->setMaxDepth($maxDepth);
 		return $tree;

--- a/files/lib/data/page/PageNodeTree.class.php
+++ b/files/lib/data/page/PageNodeTree.class.php
@@ -4,6 +4,8 @@ namespace cms\data\page;
 use cms\system\cache\builder\PageCacheBuilder;
 
 /**
+ * Generates a tree of all pages.
+ * 
  * @author	Jens Krumsieck
  * @copyright	2014 codeQuake
  * @license	GNU Lesser General Public License <http://www.gnu.org/licenses/lgpl-3.0.txt>
@@ -17,11 +19,8 @@ class PageNodeTree implements \IteratorAggregate {
 
 	protected $parentNode = null;
 
-	protected $isACP = 0;
-
-	public function __construct($parentID = null, $isACP = 0) {
+	public function __construct($parentID = null) {
 		$this->parentID = $parentID;
-		$this->isACP = $isACP;
 	}
 
 	public function buildTree() {
@@ -65,6 +64,9 @@ class PageNodeTree implements \IteratorAggregate {
 
 	protected function getNode($pageID) {
 		if (! $pageID) {
+			// @todo: This needs to be changed. It creates a
+			// pointless database query to fetch an (of course) not
+			// existing page with the id '0'
 			$page = new Page(0);
 		}
 		else {
@@ -75,8 +77,6 @@ class PageNodeTree implements \IteratorAggregate {
 	}
 
 	protected function isIncluded(PageNode $pageNode) {
-		if ($this->isACP) return true;
-		if ($pageNode->isVisible() && $pageNode->isAccessible()) return true;
-		return false;
+		return true;
 	}
 }

--- a/files/lib/data/page/ViewablePageNodeTree.class.php
+++ b/files/lib/data/page/ViewablePageNodeTree.class.php
@@ -1,0 +1,25 @@
+<?php
+namespace cms\data\page;
+
+/**
+ * Generates a tree of all viewable pages. Pages are considered as viewable
+ * when they are set as visible or the current user has the permission to see
+ * invisible pages.
+ * 
+ * @author	Florian Frantzen
+ * @copyright	2014 codeQuake
+ * @license	GNU Lesser General Public License <http://www.gnu.org/licenses/lgpl-3.0.txt>
+ * @package	de.codequake.cms
+ */
+class ViewablePageNodeTree extends PageNodeTree {
+	/**
+	 * @see	\cms\data\page\PageNodeTree::isIncluded()
+	 */
+	protected function isIncluded(PageNode $pageNode) {
+		if (!$pageNode->isVisible()) {
+			return false;
+		}
+
+		return parent::isIncluded($pageNode);
+	}
+}

--- a/files/lib/system/content/type/MenuContentType.class.php
+++ b/files/lib/system/content/type/MenuContentType.class.php
@@ -2,7 +2,7 @@
 namespace cms\system\content\type;
 
 use cms\data\content\Content;
-use cms\data\page\PageNodeTree;
+use cms\data\page\AccessiblePageNodeTree;
 use wcf\system\WCF;
 
 /**
@@ -28,7 +28,7 @@ class MenuContentType extends AbstractStructureContentType {
 				$menuItems = $content->getPage()->getChildrenTree(isset($data['depth']) && $data['depth'] != 0 ? intval($data['depth']) - 1 : null);
 				break;
 			case "all":
-				$nodeTree = new PageNodeTree();
+				$nodeTree = new AccessiblePageNodeTree();
 				$menuItems = $nodeTree->getIterator();
 				if (isset($data['depth']) && $data['depth'] != 0) $menuItems->setMaxDepth(intval($data['depth']) - 1);
 				break;

--- a/files/lib/system/sitemap/CMSSitemapProvider.class.php
+++ b/files/lib/system/sitemap/CMSSitemapProvider.class.php
@@ -1,7 +1,7 @@
 <?php
 namespace cms\system\sitemap;
 
-use cms\data\page\PageNodeTree;
+use cms\data\page\AccessiblePageNodeTree;
 use wcf\system\sitemap\ISitemapProvider;
 use wcf\system\WCF;
 
@@ -16,8 +16,9 @@ class CMSSitemapProvider implements ISitemapProvider {
 	 * @see	\wcf\system\sitemap\ISitemapProvider::getTemplate()
 	 */
 	public function getTemplate() {
-		$nodeTree = new PageNodeTree(0);
+		$nodeTree = new AccessiblePageNodeTree();
 		$nodeList = $nodeTree->getIterator();
+
 		// sitemap only supports up to child-child-pages
 		$nodeList->setMaxDepth(2);
 


### PR DESCRIPTION
- `\cms\data\page\PageNodeTree` now provides a tree of **all** pages.
- `\cms\data\page\DrainedPageNodeTree` now includes all pages but the
  specified page. Before, not accessible pages where excluded though the
  tree was only used in the acp and therefore should always contain all
  pages.
- `\cms\data\page\ViewablePageNodeTree` now provides a tree of all
  viewable pages. Pages are considered as viewable when they are set as
  visible or the current user has the permission to see invisible pages.
- `\cms\data\page\AccessiblePageNodeTree` provides a tree of all
  viewable and accessible pages. Pages are considered as accessible when
  the current user has the permission to access the page. This tree is
  identical to the old `\cms\data\page\PageNodeTree` with the second
  parameter set to `false`.
