### PR TITLE
code improvement in \cms\data\page\Page

### DIFF
--- a/files/lib/data/page/Page.class.php
+++ b/files/lib/data/page/Page.class.php
@@ -7,6 +7,9 @@ use cms\system\layout\LayoutHandler;
 use cms\system\page\PagePermissionHandler;
 use cms\system\revision\PageRevisionHandler;
 use wcf\data\ILinkableObject;
+use wcf\data\IPermissionObject;
+use wcf\system\breadcrumb\Breadcrumb;
+use wcf\system\breadcrumb\IBreadcrumbProvider;
 use wcf\system\menu\page\PageMenu;
 use wcf\system\request\IRouteController;
 use wcf\system\request\LinkHandler;
@@ -14,13 +17,13 @@ use wcf\system\WCF;
 
 /**
  * Represents a page.
- *
+ * 
  * @author	Jens Krumsieck
  * @copyright	2014 codeQuake
  * @license	GNU Lesser General Public License <http://www.gnu.org/licenses/lgpl-3.0.txt>
  * @package	de.codequake.cms
  */
-class Page extends CMSDatabaseObject implements IRouteController, ILinkableObject {
+class Page extends CMSDatabaseObject implements IBreadcrumbProvider, ILinkableObject, IPermissionObject, IRouteController {
 	/**
 	 * @see	\wcf\data\DatabaseObject::$databaseTableName
 	 */
@@ -32,12 +35,91 @@ class Page extends CMSDatabaseObject implements IRouteController, ILinkableObjec
 	protected static $databaseTableIndexName = 'pageID';
 
 	/**
-	 * @see	\wcf\data\ITitledObject::getTitle()
+	 * @see	\wcf\data\IPermissionObject::checkPermissions()
 	 */
-	public function getTitle() {
-		return WCF::getLanguage()->get($this->title);
+	public function checkPermissions(array $permissions) {
+		foreach ($permissions as $permission) {
+			if (!$this->getPermission($permission)) {
+				throw new PermissionDeniedException();
+			}
+		}
 	}
 
+	/**
+	 * Returns the 'full' alias including prepended aliases from parent
+	 * pages.
+	 *
+	 * @return	string
+	 */
+	public function getAlias() {
+		if ($this->getParentPage() !== null) {
+			return $this->getParentPage()->getAlias() . '/' . $this->alias;
+		}
+
+		return $this->alias;
+	}
+
+	/**
+	 * @see	\wcf\system\breadrcumb\IBreadcrumbProvider::getBreadcrumb()
+	 */
+	public function getBreadcrumb() {
+		return new Breadcrumb($this->getTitle(), $this->getLink());
+	}
+
+	/**
+	 * Returns a list of direct children of this page
+	 *
+	 * @return	array<\cms\data\page\Page>
+	 */
+	public function getChildren() {
+		$list = new PageList();
+		$list->getConditionBuilder()->add('page.parentID = (?)', array($this->pageID));
+		$list->readObjects();
+
+		return $list->getObjects();
+	}
+
+	/**
+	 * Returns a node tree with all children of this page.
+	 *
+	 * @param	integer		$maxDepth
+	 * @return	\cms\data\page\AccessiblePageNodeTree
+	 */
+	public function getChildrenTree($maxDepth = -1) {
+		$tree = new AccessiblePageNodeTree($this->pageID);
+		$tree = $tree->getIterator();
+
+		if ($maxDepth >= 0) {
+			$tree->setMaxDepth($maxDepth);
+		}
+
+		return $tree;
+	}
+
+	/**
+	 * Returns node trees of all contents that are assigned to this page.
+	 * Contents are grouped by their position ('body' and 'sidebar').
+	 *
+	 * @return	array<\cms\data\content\DrainedPositionContentNodeTree>
+	 */
+	public function getContents() {
+		$contentListBody = new DrainedPositionContentNodeTree(null, $this->pageID, null, 'body');
+		$contentListSidebar = new DrainedPositionContentNodeTree(null, $this->pageID, null, 'sidebar');
+
+		$contentList = array(
+			'body' => $contentListBody->getIterator(),
+			'sidebar' => $contentListSidebar->getIterator()
+		);
+
+		return $contentList;
+	}
+
+	/**
+	 * Returns the html stylesheet tag for this page. This method triggers
+	 * a stylehseet compilation in case the css files does not exist.
+	 *
+	 * @return	string
+	 */
 	public function getLayout() {
 		$stylesheets = @unserialize($this->stylesheets);
 		if (is_array($stylesheets) && !empty($stylesheets)) {
@@ -47,24 +129,103 @@ class Page extends CMSDatabaseObject implements IRouteController, ILinkableObjec
 		return '';
 	}
 
-	public function isVisible() {
-		if ($this->invisible == 1 && $this->isDisabled == 0) {
-			if ($this->getPermission('canViewInvisiblePage')) return true;
-			return false;
-		}
-		if ($this->isDisabled == 1 && $this->invisible == 0) {
-			if ($this->getPermission('canViewDisabledPage')) return true;
-			return false;
-		}
-
-		if ($this->isDisabled == 1 && $this->invisible == 1) {
-			if ($this->getPermission('canViewDisabledPage') && $this->getPermission('canViewInvisiblePage')) return true;
-			return false;
-		}
-		if ($this->getPermission('canViewPage')) return true;
-		return false;
+	/**
+	 * @see	\wcf\data\ILinkableObject::getLink()
+	 */
+	public function getLink() {
+		return LinkHandler::getInstance()->getLink('Page', array(
+			'application' => 'cms',
+			'forceFrontend' => true,
+			'alias' => $this->getAlias()
+		));
 	}
 
+	/**
+	 * Returns the menu item this page is assigned to.
+	 */
+	public function getMenuItem() {
+		foreach (PageMenu::getInstance()->getMenuItems('header') as $item) {
+			if ($item->menuItemID == $this->menuItemID) {
+				return $item;
+			}
+		}
+
+		foreach (PageMenu::getInstance()->getMenuItems('footer') as $item) {
+			if ($item->menuItemID == $this->menuItemID) {
+				return $item;
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Returns the parent page.
+	 *
+	 * @return	\cms\data\page\Page
+	 */
+	public function getParentPage() {
+		if ($this->isChild()) {
+			return PageCache::getInstance()->getPage($this->parentID);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Returns the parent pages of this page.
+	 *
+	 * @return	array<\cms\data\page\Page>
+	 */
+	public function getParentPages() {
+		if ($this->isChild()) {
+			$parentPages = array();
+			$parent = $this;
+
+			while ($parent = $parent->getParentPage()) {
+				$parentPages[] = $parent;
+			}
+
+			$parentPages = array_reverse($parentPages);
+			return $parentPages;
+		}
+
+		return array();
+	}
+
+	/**
+	 * @see	\wcf\data\IPermissionObject::getPermission()
+	 */
+	public function getPermission($permission) {
+		$permissions = PagePermissionHandler::getInstance()->getPermission($this);
+		if (isset($permissions[$permission])) {
+			return $permissions[$permission];
+		}
+
+		return WCF::getSession()->getPermission('user.cms.page.' . $permission);
+	}
+
+	/**
+	 * Returns all revisions of this page.
+	 *
+	 * @return	array<array>
+	 */
+	public function getRevisions() {
+		return PageRevisionHandler::getInstance()->getRevisions($this->pageID);
+	}
+
+	/**
+	 * @see	\wcf\data\ITitledObject::getTitle()
+	 */
+	public function getTitle() {
+		return WCF::getLanguage()->get($this->title);
+	}
+
+	/**
+	 * Returns whether the current user can access this page.
+	 *
+	 * @return	boolean
+	 */
 	public function isAccessible() {
 		if (!$this->isPublished && !WCF::getSession()->getPermission('mod.cms.canReadUnpublishedPage')) {
 			// user can't read unpublished pages
@@ -74,113 +235,51 @@ class Page extends CMSDatabaseObject implements IRouteController, ILinkableObjec
 		return $this->getPermission('canEnterPage');
 	}
 
+	/**
+	 * Returns whether this page is a child of an other page.
+	 *
+	 * @return	boolean
+	 */
 	public function isChild() {
-		if ($this->parentID) return true;
+		if ($this->parentID) {
+			return true;
+		}
+
 		return false;
 	}
 
+	/**
+	 * Returns whether this page is visible for the current user.
+	 *
+	 * @return	boolean
+	 */
+	public function isVisible() {
+		if ($this->isDisabled && !$this->getPermission('canViewDisabledPage')) {
+			// user can't view disabled pages
+			return false;
+		}
+
+		if ($this->invisible && !$this->getPermission('canViewInvisiblePage')) {
+			// user can't view invisible pages
+			return false;
+		}
+
+		return $this->getPermission('canViewPage');
+	}
+
+	/**
+	 * Returns whether this page has other pages assigned as children
+	 *
+	 * @return	boolean
+	 */
 	public function hasChildren() {
 		$list = new PageList();
-		$list->getConditionBuilder()->add('page.parentID = (?)', array(
-			$this->pageID
-		));
-		if ($list->countObjects() != 0) return true;
+		$list->getConditionBuilder()->add('page.parentID = (?)', array($this->pageID));
+
+		if ($list->countObjects() != 0) {
+			return true;
+		}
+
 		return false;
-	}
-
-	public function getChildren() {
-		$list = new PageList();
-		$list->getConditionBuilder()->add('page.parentID = (?)', array(
-			$this->pageID
-		));
-		$list->readObjects();
-		$list = $list->getObjects();
-		return $list;
-	}
-
-	public function getChildrenTree($maxDepth = -1) {
-		$tree = new AccessiblePageNodeTree($this->pageID);
-		$tree = $tree->getIterator();
-		if ($maxDepth >= 0) $tree->setMaxDepth($maxDepth);
-		return $tree;
-	}
-
-	// builds up a complete folder structure like link
-	public function getAlias() {
-		// returns page alias
-		if ($this->getParentPage() != null) {
-			return $this->getParentPage()->getAlias() . '/' . $this->alias;
-		}
-
-		return $this->alias;
-	}
-
-	public function getLink() {
-		return LinkHandler::getInstance()->getLink('Page', array(
-			'application' => 'cms',
-			'forceFrontend' => true,
-			'alias' => $this->getAlias()
-		));
-	}
-
-	public function getParentPage() {
-		if ($this->isChild()) {
-			return PageCache::getInstance()->getPage($this->parentID);
-		}
-		return null;
-	}
-
-	public function getParentPages() {
-		if ($this->isChild()) {
-			$parentPages = array();
-			$parent = $this;
-			while ($parent = $parent->getParentPage()) {
-				$parentPages[] = $parent;
-			}
-			$parentPages = array_reverse($parentPages);
-			return $parentPages;
-		}
-		return array();
-	}
-
-	public function getContents() {
-		$contentListBody = new DrainedPositionContentNodeTree(null, $this->pageID, null, 'body');
-		$contentListSidebar = new DrainedPositionContentNodeTree(null, $this->pageID, null, 'sidebar');
-		$contentList = array(
-			'body' => $contentListBody->getIterator(),
-			'sidebar' => $contentListSidebar->getIterator()
-		);
-		return $contentList;
-	}
-
-	public function getRevisions() {
-		//gets page revisions
-		return PageRevisionHandler::getInstance()->getRevisions($this->pageID);
-	}
-
-	public function getPermission($permission = 'canViewPage') {
-		$permissions = PagePermissionHandler::getInstance()->getPermission($this);
-		if (isset($permissions[$permission])) {
-			return $permissions[$permission];
-		}
-		return WCF::getSession()->getPermission('user.cms.page.' . $permission);
-	}
-
-	public function checkPermission(array $permissions = array('canViewPage')) {
-		foreach ($permissions as $permission) {
-			if (! $this->getPermission($permission)) {
-				throw new PermissionDeniedException();
-			}
-		}
-	}
-
-	public function getMenuItem() {
-		foreach (PageMenu::getInstance()->getMenuItems('header') as $item) {
-			if ($item->menuItemID == $this->menuItemID) return $item;
-		}
-		foreach (PageMenu::getInstance()->getMenuItems('footer') as $item) {
-			if ($item->menuItemID == $this->menuItemID) return $item;
-		}
-		return null;
 	}
 }

--- a/files/lib/system/CMSCore.class.php
+++ b/files/lib/system/CMSCore.class.php
@@ -5,7 +5,6 @@ use cms\data\page\Page;
 use cms\data\page\PageCache;
 use cms\system\menu\page\CMSPageMenuItemProvider;
 use wcf\system\application\AbstractApplication;
-use wcf\system\breadcrumb\Breadcrumb;
 use wcf\system\menu\page\PageMenu;
 use wcf\system\WCF;
 
@@ -66,7 +65,7 @@ class CMSCore extends AbstractApplication {
 
 		// add breadcrumbs
 		foreach ($page->getParentPages() as $child) {
-			WCF::getBreadcrumbs()->add(new Breadcrumb($child->getTitle(), $child->getLink()));
+			WCF::getBreadcrumbs()->add($child->getBreadcrumb());
 		}
 	}
 }


### PR DESCRIPTION
- order methods by their name
- documentation of methods
- implement `\wcf\system\breadcrumb\IBreadcrumbProvider` and add
  `getBreadcrumb`
- rewrite `isVisible` to take `canViewPage` into account when page is
  invisible or disabled as well
- implement `\wcf\data\IPermissionObject`. Therefore, default values of
  `getPermission` and `checkPermissions` where removed
