### PR TITLE
improve \cms\data\page\PageAction

### DIFF
--- a/acptemplates/contentTypeList.tpl
+++ b/acptemplates/contentTypeList.tpl
@@ -5,7 +5,7 @@
 		<ul class="containerBoxList tripleColumned">
 			{foreach from=$types item=type}
 				<li>
-					<a href="{link controller='ContentAdd' application='cms' id=$pageID}objectType={$type->objectType}&position={$position}&parentID={$parentID}{/link}"><span class="icon icon16 {$type->getProcessor()->getIcon()}"></span> {lang}cms.acp.content.type.{$type->objectType}{/lang}</a>
+					<a href="{link controller='ContentAdd' application='cms' id=$page->pageID}objectType={$type->objectType}&position={$position}&parentID={$parentID}{/link}"><span class="icon icon16 {$type->getProcessor()->getIcon()}"></span> {lang}cms.acp.content.type.{$type->objectType}{/lang}</a>
 				</li>
 			{/foreach}
 		</ul>


### PR DESCRIPTION
- use `getSingleObject` instead of validating ourself that only one
  object id is given. Moreover, used ids are forced now.
- improve handling of body and sidebar contents
